### PR TITLE
Update README about minimum iOS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add react-native-bottom-tabs
 
 If you use React Native version 0.75 or lower:
 
-- For CLI template users, open Podfile in ios folder and change minimum iOS version to `14.0` before `pod install`
+- For `@react-native-community/cli` users, open Podfile in ios folder and change minimum iOS version to `14.0` before `pod install`
 
 ```patch
 -platform :ios, min_ios_version_supported

--- a/README.md
+++ b/README.md
@@ -17,11 +17,32 @@ https://github.com/user-attachments/assets/fbdd9ce2-f4b9-4d0c-bd91-2e62bb422d69
 yarn add react-native-bottom-tabs
 ```
 
-If you use React Native version 0.75 or lower, open Podfile and change minimum iOS version to `14.0` before `pod install`
+If you use React Native version 0.75 or lower:
+
+- For CLI template users, open Podfile in ios folder and change minimum iOS version to `14.0` before `pod install`
 
 ```patch
 -platform :ios, min_ios_version_supported
 +platform :ios, '14.0'
+```
+
+- For Expo users, install `expo-build-properties`, open app.json file and update `deploymentTarget` for `ios` as below
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "deploymentTarget": "14.0"
+          }
+        }
+      ]
+    ],
+  }
+}
 ```
 
 ## 📖 Documentation

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/user-attachments/assets/fbdd9ce2-f4b9-4d0c-bd91-2e62bb422d69
 yarn add react-native-bottom-tabs
 ```
 
-This library supports iOS 14 or higher to run. Open Podfile and change minimum iOS version before `pod install`
+If you use React Native version 0.75 or lower, open Podfile and change minimum iOS version to `14.0` before `pod install`
 
 ```patch
 -platform :ios, min_ios_version_supported

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ https://github.com/user-attachments/assets/fbdd9ce2-f4b9-4d0c-bd91-2e62bb422d69
 yarn add react-native-bottom-tabs
 ```
 
+This library supports iOS 14 or higher to run. Open Podfile and change minimum iOS version before `pod install`
+
+```patch
+-platform :ios, min_ios_version_supported
++platform :ios, '14.0'
+```
+
 ## 📖 Documentation
 
 ### Usage with React Navigation


### PR DESCRIPTION
I hit this error when `pod install`

```bash
[!] CocoaPods could not find compatible versions for pod "react-native-bottom-tabs":
  In Podfile:
    react-native-bottom-tabs (from `../node_modules/react-native-bottom-tabs`)

Specs satisfying the `react-native-bottom-tabs (from `../node_modules/react-native-bottom-tabs`)` dependency were found, but they required a higher minimum deployment target.
```

So I update README about minimum iOS version.