### PR TITLE
fix: switch from SwiftUI to Swift, fixes safe area handling

### DIFF
--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -1,114 +1,69 @@
-import Foundation
-import SwiftUI
-import React
+import UIKit
 
-/**
- Props that component accepts. SwiftUI view gets re-rendered when ObservableObject changes.
- */
-class TabViewProps: ObservableObject {
-  @Published var children: [UIView]?
-  @Published var config: TabViewConfig?
-  @Published var items: TabData?
-  @Published var selectedPage: String?
-  @Published var icons: [Int: UIImage] = [:]
+class TabViewProps {
+    var children: [UIView]?
+    var config: TabViewConfig?
+    var items: TabData?
+    var selectedPage: String?
+    var icons: [Int: UIImage] = [:]
 }
 
-/**
- Helper used to render UIView inside of SwiftUI.
- */
-struct RepresentableView: UIViewRepresentable {
-  var view: UIView
-  func makeUIView(context: Context) -> UIView {
-    return view
-  }
-  func updateUIView(_ uiView: UIView, context: Context) {
-  }
+class TabViewImpl: UITabBarController {
+    var props: TabViewProps
+    var onSelect: (_ key: String) -> Void
+
+    init(props: TabViewProps, onSelect: @escaping (_ key: String) -> Void) {
+        self.props = props
+        self.onSelect = onSelect
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupTabs()
+    }
+
+    func setupTabs() {
+        guard let children = props.children, let items = props.items?.tabs else { return }
+
+        var viewControllers: [UIViewController] = []
+        
+        for (index, childView) in children.enumerated() {
+            let childViewController = UIViewController()
+            childViewController.view = childView
+            let tabData = items[safe: index]
+            
+            // Configure the tab bar item
+            let tabBarItem = UITabBarItem(title: tabData?.title, image: props.icons[index], tag: index)
+            if let badge = tabData?.badge, !badge.isEmpty {
+                tabBarItem.badgeValue = badge
+            }
+            childViewController.tabBarItem = tabBarItem
+            
+            viewControllers.append(childViewController)
+        }
+        
+        self.viewControllers = viewControllers
+        // Optionally select the initial tab
+        if let selectedPage = props.selectedPage, let initialIndex = items.firstIndex(where: { $0.key == selectedPage }) {
+            self.selectedIndex = initialIndex
+        }
+        
+        self.delegate = self
+    }
 }
 
-/**
- SwiftUI implementation of TabView used to render React Native views.
- */
-struct TabViewImpl: View {
-  @ObservedObject var props: TabViewProps
-  var onSelect: (_ key: String) -> Void
-
-  var body: some View {
-    TabView(selection: $props.selectedPage) {
-      ForEach(props.children?.indices ?? 0..<0, id: \.self) { index in
-        let child = props.children?[safe: index] ?? UIView()
-        let tabData = props.items?.tabs[safe: index]
-        let icon = props.icons[index]
-
-        RepresentableView(view: child)
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-          .tabItem {
-            TabItem(
-              title: tabData?.title,
-              icon: icon,
-              sfSymbol: tabData?.sfSymbol,
-              labeled: props.config?.labeled
-            )
-          }
-          .tag(tabData?.key)
-          .tabBadge(tabData?.badge)
-      }
+// Implementing UITabBarControllerDelegate to handle tab selection
+extension TabViewImpl: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        if let index = tabBarController.viewControllers?.firstIndex(of: viewController),
+           let tabData = props.items?.tabs[safe: index] {
+            onSelect(tabData.key)
+        }
     }
-    .getSidebarAdaptable(enabled: props.config?.sidebarAdaptable ?? false)
-    .onChange(of: props.selectedPage ?? "") { newValue in
-      onSelect(newValue)
-    }
-    .onAppear {
-      if #available(iOS 15.0, *) {
-        // This causes issues with lazy loading making the TabView background blink.
-        let appearance = UITabBarAppearance()
-        UITabBar.appearance().scrollEdgeAppearance = appearance
-      }
-    }
-  }
-}
-
-struct TabItem: View {
-  var title: String?
-  var icon: UIImage?
-  var sfSymbol: String?
-  var labeled: Bool?
-
-  var body: some View {
-    if let icon {
-      Image(uiImage: icon)
-    } else if let sfSymbol, !sfSymbol.isEmpty {
-      Image(systemName: sfSymbol)
-    }
-    if (labeled != false) {
-      Text(title ?? "")
-    }
-  }
-}
-
-extension View {
-  @ViewBuilder
-  func getSidebarAdaptable(enabled: Bool) -> some View {
-    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, *) {
-      if (enabled) {
-        self.tabViewStyle(.sidebarAdaptable)
-      } else {
-        self
-      }
-    } else {
-      self
-    }
-  }
-
-  @ViewBuilder
-  func tabBadge(_ data: String?) -> some View {
-    if #available(iOS 15.0, macOS 15.0, visionOS 2.0, *) {
-      if let data = data, !data.isEmpty {
-        self.badge(data)
-      } else {
-        self
-      }
-    } else {
-      self
-    }
-  }
 }

--- a/ios/TabViewProvider.swift
+++ b/ios/TabViewProvider.swift
@@ -20,7 +20,7 @@ struct TabData: Codable {
 
 @objc public class TabViewProvider: UIView {
   var props = TabViewProps()
-  private var hostingController: UIHostingController<TabViewImpl>?
+  private var hostingController: TabViewImpl?
   private var coalescingKey: UInt16 = 0
   private var eventDispatcher: RCTEventDispatcherProtocol?
   private var imageLoader: RCTImageLoaderProtocol?
@@ -74,10 +74,10 @@ struct TabData: Codable {
       return
     }
     
-    self.hostingController = UIHostingController(rootView: TabViewImpl(props: props) { key in
+    self.hostingController = TabViewImpl(props: props) { key in
       self.coalescingKey += 1
       self.eventDispatcher?.send(PageSelectedEvent(reactTag: self.reactTag, key: NSString(string: key), coalescingKey: self.coalescingKey))
-    })
+    }
     if let hostingController = self.hostingController, let parentViewController = reactViewController() {
       parentViewController.addChild(hostingController)
       addSubview(hostingController.view)


### PR DESCRIPTION
It seems that switching from SwiftUI to Swift/UIKit, the ScrollView respects the TabBar...