### PR TITLE
fix: trim routes for android - no more then 6 tabs

### DIFF
--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -180,7 +180,7 @@ const TabView = <Route extends BaseRoute>({
           <View
             key={route.key}
             style={[
-              { width: '100%', height: '100%' },
+              styles.sceneContainer,
               Platform.OS === 'android' && {
                 display: route.key === focusedKey ? 'flex' : 'none',
               },
@@ -199,6 +199,10 @@ const TabView = <Route extends BaseRoute>({
 
 const styles = StyleSheet.create({
   fullWidth: {
+    width: '100%',
+    height: '100%',
+  },
+  sceneContainer: {
     width: '100%',
     height: '100%',
   },

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -70,7 +70,7 @@ interface Props<Route extends BaseRoute> {
   }) => ImageSource | undefined;
 }
 
-const MAX_TABS = 6;
+const ANDROID_MAX_TABS = 6;
 
 const TabView = <Route extends BaseRoute>({
   navigationState,
@@ -90,14 +90,17 @@ const TabView = <Route extends BaseRoute>({
   const focusedKey = navigationState.routes[navigationState.index].key;
 
   const trimmedRoutes = useMemo(() => {
-    if (Platform.OS === 'android' && navigationState.routes.length > MAX_TABS) {
-      console.warn(`TabView only supports up to ${MAX_TABS} tabs on Android`);
-      return navigationState.routes.slice(0, MAX_TABS);
+    if (
+      Platform.OS === 'android' &&
+      navigationState.routes.length > ANDROID_MAX_TABS
+    ) {
+      console.warn(
+        `TabView only supports up to ${ANDROID_MAX_TABS} tabs on Android`
+      );
+      return navigationState.routes.slice(0, ANDROID_MAX_TABS);
     }
     return navigationState.routes;
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [navigationState.routes]);
 
   /**
    * List of loaded tabs, tabs will be loaded when navigated to.
@@ -182,7 +185,7 @@ const TabView = <Route extends BaseRoute>({
           <View
             key={route.key}
             style={[
-              styles.sceneContainer,
+              styles.fullWidth,
               Platform.OS === 'android' && {
                 display: route.key === focusedKey ? 'flex' : 'none',
               },
@@ -201,10 +204,6 @@ const TabView = <Route extends BaseRoute>({
 
 const styles = StyleSheet.create({
   fullWidth: {
-    width: '100%',
-    height: '100%',
-  },
-  sceneContainer: {
     width: '100%',
     height: '100%',
   },

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -95,7 +95,9 @@ const TabView = <Route extends BaseRoute>({
       return navigationState.routes.slice(0, MAX_TABS);
     }
     return navigationState.routes;
-  }, [navigationState.routes]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /**
    * List of loaded tabs, tabs will be loaded when navigated to.

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -70,6 +70,8 @@ interface Props<Route extends BaseRoute> {
   }) => ImageSource | undefined;
 }
 
+const MAX_TABS = 6;
+
 const TabView = <Route extends BaseRoute>({
   navigationState,
   renderScene,
@@ -87,9 +89,13 @@ const TabView = <Route extends BaseRoute>({
   // @ts-ignore
   const focusedKey = navigationState.routes[navigationState.index].key;
 
-  if (navigationState.routes.length > 6) {
-    throw new Error('TabView only supports up to 6 tabs');
-  }
+  const trimmedRoutes = useMemo(() => {
+    if (Platform.OS === 'android' && navigationState.routes.length > MAX_TABS) {
+      console.warn(`TabView only supports up to ${MAX_TABS} tabs on Android`);
+      return navigationState.routes.slice(0, MAX_TABS);
+    }
+    return navigationState.routes;
+  }, [navigationState.routes]);
 
   /**
    * List of loaded tabs, tabs will be loaded when navigated to.
@@ -103,18 +109,18 @@ const TabView = <Route extends BaseRoute>({
 
   const icons = useMemo(
     () =>
-      navigationState.routes.map((route) =>
+      trimmedRoutes.map((route) =>
         getIcon({
           route,
           focused: route.key === focusedKey,
         })
       ),
-    [focusedKey, getIcon, navigationState.routes]
+    [focusedKey, getIcon, trimmedRoutes]
   );
 
   const items: TabViewItems = useMemo(
     () =>
-      navigationState.routes.map((route, index) => {
+      trimmedRoutes.map((route, index) => {
         const icon = icons[index];
         const isSfSymbol = isAppleSymbol(icon);
 
@@ -130,7 +136,7 @@ const TabView = <Route extends BaseRoute>({
           badge: props.getBadge?.({ route }),
         };
       }),
-    [getLabelText, icons, navigationState.routes, props]
+    [getLabelText, icons, trimmedRoutes, props]
   );
 
   const resolvedIconAssets: ImageSource[] = useMemo(
@@ -145,9 +151,7 @@ const TabView = <Route extends BaseRoute>({
   );
 
   const jumpTo = useLatestCallback((key: string) => {
-    const index = navigationState.routes.findIndex(
-      (route) => route.key === key
-    );
+    const index = trimmedRoutes.findIndex((route) => route.key === key);
 
     onIndexChange(index);
   });
@@ -163,7 +167,7 @@ const TabView = <Route extends BaseRoute>({
       }}
       {...props}
     >
-      {navigationState.routes.map((route) => {
+      {trimmedRoutes.map((route) => {
         if (getLazy({ route }) !== false && !loaded.includes(route.key)) {
           // Don't render a screen if we've never navigated to it
           if (Platform.OS === 'android') {


### PR DESCRIPTION
This PR fixes issue https://github.com/okwasniewski/react-native-bottom-tabs/issues/13

Right now it will show a warning if there are more than 6 tabs on android and will only show 6 tabs and trims the other tabs.



https://github.com/user-attachments/assets/4ebfbffa-2c26-4332-b3b8-35d6337206db

