### PR TITLE
Adding Active Inactive Tint Color

### DIFF
--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -32,6 +32,10 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   private var isAnimating = false
   private var activeTintColor: Int? = null
   private var inactiveTintColor: Int? = null
+  private val checkedStateSet = intArrayOf(android.R.attr.state_checked)
+  private val uncheckedStateSet = intArrayOf(-android.R.attr.state_checked)
+  private val disabledStateSet = intArrayOf(-android.R.attr.state_enabled)
+
 
   private val layoutCallback = Choreographer.FrameCallback {
     isLayoutEnqueued = false
@@ -162,32 +166,6 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
     itemBackground = colorDrawable
   }
 
-  private fun getDefaultColorFor(baseColorThemeAttr: Int): Int? {
-    val value = TypedValue()
-    if (!context.theme.resolveAttribute(baseColorThemeAttr, value, true)) {
-      return null
-    }
-    val baseColor = AppCompatResources.getColorStateList(context, value.resourceId)
-    return baseColor.defaultColor
-  }
-
-  private fun updateTintColors() {
-    val activeColor = activeTintColor ?: return
-    val inactiveColor = inactiveTintColor ?: return
-
-    val states = arrayOf(
-      intArrayOf(-android.R.attr.state_checked),
-      intArrayOf(android.R.attr.state_checked)
-    )
-
-    val colors = intArrayOf(inactiveColor, activeColor)
-
-    ColorStateList(states, colors).apply {
-      this@ReactBottomNavigationView.itemTextColor = this
-      this@ReactBottomNavigationView.itemIconTintList = this
-    }
-  }
-
   fun setActiveTintColor(color: Int?) {
     activeTintColor = color
     updateTintColors()
@@ -196,5 +174,30 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   fun setInactiveTintColor(color: Int?) {
     inactiveTintColor = color
     updateTintColors()
+  }
+
+  private fun updateTintColors() {
+    // getDeaultColor will always return a valid color but to satisfy the compiler we need to check for null
+    val colorPrimary = activeTintColor ?: getDefaultColorFor(android.R.attr.colorPrimary) ?: return
+    val colorSecondary =
+      inactiveTintColor ?: getDefaultColorFor(android.R.attr.textColorSecondary) ?: return
+    val states = arrayOf(uncheckedStateSet, checkedStateSet)
+    val colors = intArrayOf(colorSecondary, colorPrimary)
+
+    ColorStateList(states, colors).apply {
+      this@ReactBottomNavigationView.itemTextColor = this
+      this@ReactBottomNavigationView.itemIconTintList = this
+    }
+  }
+
+  private fun getDefaultColorFor(baseColorThemeAttr: Int): Int? {
+    val value = TypedValue()
+    if (!context.theme.resolveAttribute(baseColorThemeAttr, value, true)) {
+      return null
+    }
+    val baseColor = AppCompatResources.getColorStateList(
+      context, value.resourceId
+    )
+    return baseColor.defaultColor
   }
 }

--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -1,6 +1,5 @@
 package com.rcttabview
 
-import android.R.attr
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
@@ -173,33 +172,29 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   }
 
   private fun updateTintColors() {
-    if (activeTintColor == null || inactiveTintColor == null) {
-      return;
-    }
+    val activeColor = activeTintColor ?: return
+    val inactiveColor = inactiveTintColor ?: return
 
     val states = arrayOf(
-      intArrayOf(-attr.state_checked),
-      intArrayOf(attr.state_checked)
-    )
-    val colors = intArrayOf(
-      inactiveTintColor as Int,
-      activeTintColor as Int
+      intArrayOf(-android.R.attr.state_checked),
+      intArrayOf(android.R.attr.state_checked)
     )
 
-    this.itemTextColor = ColorStateList(states, colors)
+    val colors = intArrayOf(inactiveColor, activeColor)
 
-    this.itemIconTintList = ColorStateList(
-      states, colors
-    )
+    ColorStateList(states, colors).apply {
+      this@ReactBottomNavigationView.itemTextColor = this
+      this@ReactBottomNavigationView.itemIconTintList = this
+    }
   }
 
   fun setActiveTintColor(color: Int?) {
-      activeTintColor = color
-      this.updateTintColors()
+    activeTintColor = color
+    updateTintColors()
   }
 
   fun setInactiveTintColor(color: Int?) {
-      inactiveTintColor = color
-      this.updateTintColors()
+    inactiveTintColor = color
+    updateTintColors()
   }
 }

--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -1,5 +1,6 @@
 package com.rcttabview
 
+import android.R.attr
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
@@ -30,6 +31,8 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   var items: MutableList<TabInfo>? = null
   var onTabSelectedListener: ((WritableMap) -> Unit)? = null
   private var isAnimating = false
+  private var activeTintColor: Int? = null
+  private var inactiveTintColor: Int? = null
 
   private val layoutCallback = Choreographer.FrameCallback {
     isLayoutEnqueued = false
@@ -167,5 +170,36 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
     }
     val baseColor = AppCompatResources.getColorStateList(context, value.resourceId)
     return baseColor.defaultColor
+  }
+
+  private fun updateTintColors() {
+    if (activeTintColor == null || inactiveTintColor == null) {
+      return;
+    }
+
+    val states = arrayOf(
+      intArrayOf(-attr.state_checked),
+      intArrayOf(attr.state_checked)
+    )
+    val colors = intArrayOf(
+      inactiveTintColor as Int,
+      activeTintColor as Int
+    )
+
+    this.itemTextColor = ColorStateList(states, colors)
+
+    this.itemIconTintList = ColorStateList(
+      states, colors
+    )
+  }
+
+  fun setActiveTintColor(color: Int?) {
+      activeTintColor = color
+      this.updateTintColors()
+  }
+
+  fun setInactiveTintColor(color: Int?) {
+      inactiveTintColor = color
+      this.updateTintColors()
   }
 }

--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -34,8 +34,6 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   private var inactiveTintColor: Int? = null
   private val checkedStateSet = intArrayOf(android.R.attr.state_checked)
   private val uncheckedStateSet = intArrayOf(-android.R.attr.state_checked)
-  private val disabledStateSet = intArrayOf(-android.R.attr.state_enabled)
-
 
   private val layoutCallback = Choreographer.FrameCallback {
     isLayoutEnqueued = false
@@ -49,6 +47,7 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   init {
     setOnItemSelectedListener { item ->
       onTabSelected(item)
+      updateTintColors(item)
       true
     }
   }
@@ -176,9 +175,12 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
     updateTintColors()
   }
 
-  private fun updateTintColors() {
+  private fun updateTintColors(item: MenuItem? = null) {
+    // First let's check current item color.
+    val currentItemTintColor = items?.find { it.title == item?.title }?.activeTintColor
+
     // getDeaultColor will always return a valid color but to satisfy the compiler we need to check for null
-    val colorPrimary = activeTintColor ?: getDefaultColorFor(android.R.attr.colorPrimary) ?: return
+    val colorPrimary = currentItemTintColor ?: activeTintColor ?: getDefaultColorFor(android.R.attr.colorPrimary) ?: return
     val colorSecondary =
       inactiveTintColor ?: getDefaultColorFor(android.R.attr.textColorSecondary) ?: return
     val states = arrayOf(uncheckedStateSet, checkedStateSet)

--- a/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
@@ -21,7 +21,8 @@ import com.facebook.yoga.YogaNode
 data class TabInfo(
   val key: String,
   val title: String,
-  val badge: String
+  val badge: String,
+  val activeTintColor: Int?
 )
 
 @ReactModule(name = RCTTabViewViewManager.NAME)
@@ -42,7 +43,8 @@ class RCTTabViewViewManager :
           TabInfo(
             key = item.getString("key") ?: "",
             title = item.getString("title") ?: "",
-            badge = item.getString("badge") ?: ""
+            badge = item.getString("badge") ?: "",
+            activeTintColor = if (item.hasKey("activeTintColor")) item.getInt("activeTintColor") else null
           )
         )
       }
@@ -56,7 +58,6 @@ class RCTTabViewViewManager :
       view.selectedItemId = it
     }
   }
-
 
   @ReactProp(name = "labeled")
   fun setLabeled(view: ReactBottomNavigationView, flag: Boolean?) {
@@ -81,10 +82,6 @@ class RCTTabViewViewManager :
     }
   }
 
-  @ReactProp(name = "translucent")
-  fun setTranslucentview(view: ReactBottomNavigationView, translucent: Boolean?) {
-  }
-
   @ReactProp(name = "activeTintColor")
   fun setActiveTintColor(view: ReactBottomNavigationView, color: Int?) {
     view.setActiveTintColor(color)
@@ -105,7 +102,6 @@ class RCTTabViewViewManager :
     }
     return view
   }
-
 
   class TabViewShadowNode() : LayoutShadowNode(),
     YogaMeasureFunction {
@@ -170,5 +166,9 @@ class RCTTabViewViewManager :
 
   @ReactProp(name = "disablePageAnimations")
   fun setDisablePageAnimations(view: ReactBottomNavigationView, flag: Boolean) {
+  }
+
+  @ReactProp(name = "translucent")
+  fun setTranslucentview(view: ReactBottomNavigationView, translucent: Boolean?) {
   }
 }

--- a/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
@@ -72,7 +72,7 @@ class RCTTabViewViewManager :
   fun setBarTintColor(view: ReactBottomNavigationView, color: Int?) {
     view.setBarTintColor(color)
   }
-  
+
   @ReactProp(name = "rippleColor")
   fun setRippleColor(view: ReactBottomNavigationView, rippleColor: Int?) {
     if (rippleColor != null) {
@@ -83,6 +83,16 @@ class RCTTabViewViewManager :
 
   @ReactProp(name = "translucent")
   fun setTranslucentview(view: ReactBottomNavigationView, translucent: Boolean?) {
+  }
+
+  @ReactProp(name = "activeTintColor")
+  fun setActiveTintColor(view: ReactBottomNavigationView, color: Int?) {
+    view.setActiveTintColor(color)
+  }
+
+  @ReactProp(name = "inactiveTintColor")
+  fun setInactiveTintColor(view: ReactBottomNavigationView, color: Int?) {
+    view.setInactiveTintColor(color)
   }
 
   public override fun createViewInstance(context: ThemedReactContext): ReactBottomNavigationView {

--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -65,6 +65,14 @@ Whether to disable page animations between tabs.
 
 Describes the appearance attributes for the tabBar to use when an observable scroll view is scrolled to the bottom.
 
+### `activeTintColor`
+
+Color for the active tab.
+
+### `inactiveTintColor`
+
+Color for the inactive tabs.
+
 #### `barTintColor`
 
 Background color of the tab bar.
@@ -105,6 +113,14 @@ Title text for the screen.
 #### `tabBarLabel`
 
 Label text of the tab displayed in the navigation bar. When undefined, scene title is used.
+
+#### `tabBarActiveTintColor`
+
+Color for the active tab.
+
+:::note
+The `tabBarInactiveTintColor` is not supported due to native limitations. Use `inactiveTintColor` in the `Tab.Navigator` instead.
+:::
 
 #### `tabBarIcon`
 

--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -65,11 +65,11 @@ Whether to disable page animations between tabs.
 
 Describes the appearance attributes for the tabBar to use when an observable scroll view is scrolled to the bottom.
 
-### `activeTintColor`
+### `tabBarActiveTintColor`
 
 Color for the active tab.
 
-### `inactiveTintColor`
+### `tabBarInactiveTintColor`
 
 Color for the inactive tabs.
 
@@ -119,7 +119,7 @@ Label text of the tab displayed in the navigation bar. When undefined, scene tit
 Color for the active tab.
 
 :::note
-The `tabBarInactiveTintColor` is not supported due to native limitations. Use `inactiveTintColor` in the `Tab.Navigator` instead.
+The `tabBarInactiveTintColor` is not supported on route level due to native limitations. Use `inactiveTintColor` in the `Tab.Navigator` instead.
 :::
 
 #### `tabBarIcon`

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,8 +10,10 @@ import {
   TouchableOpacity,
   Button,
   Alert,
+  useColorScheme,
 } from 'react-native';
 import {
+  DarkTheme,
   DefaultTheme,
   NavigationContainer,
   useNavigation,
@@ -26,6 +28,7 @@ import MaterialBottomTabs from './Examples/MaterialBottomTabs';
 import SFSymbols from './Examples/SFSymbols';
 import LabeledTabs from './Examples/Labeled';
 import NativeBottomTabs from './Examples/NativeBottomTabs';
+import TintColorsExample from './Examples/TintColors';
 
 const FourTabsIgnoreSafeArea = () => {
   return <FourTabs ignoresTopSafeArea />;
@@ -86,6 +89,7 @@ const examples = [
     screenOptions: { headerShown: false },
   },
   { component: MaterialBottomTabs, name: 'Material (JS) Bottom Tabs' },
+  { component: TintColorsExample, name: 'Tint Colors' },
 ];
 
 function App() {
@@ -116,17 +120,12 @@ const NativeStack = createNativeStackNavigator();
 export default function Navigation() {
   const [mode, setMode] = React.useState<'native' | 'js'>('native');
   const NavigationStack = mode === 'js' ? Stack : NativeStack;
+  const colorScheme = useColorScheme();
+  const theme = colorScheme === 'dark' ? DarkTheme : DefaultTheme;
+
   return (
     <SafeAreaProvider>
-      <NavigationContainer
-        theme={{
-          ...DefaultTheme,
-          colors: {
-            ...DefaultTheme.colors,
-            primary: 'black',
-          },
-        }}
-      >
+      <NavigationContainer theme={theme}>
         <NavigationStack.Navigator initialRouteName="BottomTabs Example">
           <NavigationStack.Screen
             name="BottomTabs Example"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -11,7 +11,11 @@ import {
   Button,
   Alert,
 } from 'react-native';
-import { NavigationContainer, useNavigation } from '@react-navigation/native';
+import {
+  DefaultTheme,
+  NavigationContainer,
+  useNavigation,
+} from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -114,7 +118,15 @@ export default function Navigation() {
   const NavigationStack = mode === 'js' ? Stack : NativeStack;
   return (
     <SafeAreaProvider>
-      <NavigationContainer>
+      <NavigationContainer
+        theme={{
+          ...DefaultTheme,
+          colors: {
+            ...DefaultTheme.colors,
+            primary: 'black',
+          },
+        }}
+      >
         <NavigationStack.Navigator initialRouteName="BottomTabs Example">
           <NavigationStack.Screen
             name="BottomTabs Example"

--- a/example/src/Examples/NativeBottomTabs.tsx
+++ b/example/src/Examples/NativeBottomTabs.tsx
@@ -9,7 +9,7 @@ const Tab = createNativeBottomTabNavigator();
 
 function NativeBottomTabs() {
   return (
-    <Tab.Navigator inactiveTintColor="red" activeTintColor="orange">
+    <Tab.Navigator tabBarInactiveTintColor="red" tabBarActiveTintColor="orange">
       <Tab.Screen
         name="Article"
         component={Article}
@@ -41,6 +41,7 @@ function NativeBottomTabs() {
         component={Chat}
         options={{
           tabBarIcon: () => require('../../assets/icons/chat_dark.png'),
+          tabBarActiveTintColor: 'purple',
         }}
       />
     </Tab.Navigator>

--- a/example/src/Examples/NativeBottomTabs.tsx
+++ b/example/src/Examples/NativeBottomTabs.tsx
@@ -9,7 +9,7 @@ const Tab = createNativeBottomTabNavigator();
 
 function NativeBottomTabs() {
   return (
-    <Tab.Navigator>
+    <Tab.Navigator inactiveTintColor="blue">
       <Tab.Screen
         name="Article"
         component={Article}

--- a/example/src/Examples/NativeBottomTabs.tsx
+++ b/example/src/Examples/NativeBottomTabs.tsx
@@ -9,7 +9,7 @@ const Tab = createNativeBottomTabNavigator();
 
 function NativeBottomTabs() {
   return (
-    <Tab.Navigator inactiveTintColor="blue">
+    <Tab.Navigator inactiveTintColor="red" activeTintColor="orange">
       <Tab.Screen
         name="Article"
         component={Article}
@@ -33,6 +33,7 @@ function NativeBottomTabs() {
         component={Contacts}
         options={{
           tabBarIcon: () => require('../../assets/icons/person_dark.png'),
+          tabBarActiveTintColor: 'yellow',
         }}
       />
       <Tab.Screen

--- a/example/src/Examples/TintColors.tsx
+++ b/example/src/Examples/TintColors.tsx
@@ -48,8 +48,8 @@ export default function TintColorsExample() {
       navigationState={{ index, routes }}
       onIndexChange={setIndex}
       renderScene={renderScene}
-      inactiveTintColor="red"
-      activeTintColor="orange"
+      tabBarActiveTintColor="red"
+      tabBarInactiveTintColor="orange"
       scrollEdgeAppearance="default"
     />
   );

--- a/example/src/Examples/TintColors.tsx
+++ b/example/src/Examples/TintColors.tsx
@@ -26,6 +26,7 @@ export default function TintColorsExample() {
       key: 'contacts',
       focusedIcon: require('../../assets/icons/person_dark.png'),
       title: 'Contacts',
+      activeTintColor: 'yellow',
     },
     {
       key: 'chat',
@@ -48,6 +49,7 @@ export default function TintColorsExample() {
       onIndexChange={setIndex}
       renderScene={renderScene}
       inactiveTintColor="red"
+      activeTintColor="orange"
       scrollEdgeAppearance="default"
     />
   );

--- a/example/src/Examples/TintColors.tsx
+++ b/example/src/Examples/TintColors.tsx
@@ -1,0 +1,53 @@
+import TabView, { SceneMap } from 'react-native-bottom-tabs';
+import { useState } from 'react';
+import { Article } from '../Screens/Article';
+import { Albums } from '../Screens/Albums';
+import { Contacts } from '../Screens/Contacts';
+import { Chat } from '../Screens/Chat';
+
+export default function TintColorsExample() {
+  const [index, setIndex] = useState(0);
+  const [routes] = useState([
+    {
+      key: 'article',
+      title: 'Article',
+      focusedIcon: require('../../assets/icons/article_dark.png'),
+      unfocusedIcon: require('../../assets/icons/chat_dark.png'),
+      badge: '!',
+    },
+    {
+      key: 'albums',
+      title: 'Albums',
+      focusedIcon: require('../../assets/icons/grid_dark.png'),
+      badge: '5',
+    },
+    {
+      key: 'contacts',
+      focusedIcon: require('../../assets/icons/person_dark.png'),
+      title: 'Contacts',
+    },
+    {
+      key: 'chat',
+      focusedIcon: require('../../assets/icons/chat_dark.png'),
+      title: 'Chat',
+    },
+  ]);
+
+  const renderScene = SceneMap({
+    article: Article,
+    albums: Albums,
+    contacts: Contacts,
+    chat: Chat,
+  });
+
+  return (
+    <TabView
+      sidebarAdaptable
+      navigationState={{ index, routes }}
+      onIndexChange={setIndex}
+      renderScene={renderScene}
+      activeTintColor="red"
+      inactiveTintColor="blue"
+    />
+  );
+}

--- a/example/src/Examples/TintColors.tsx
+++ b/example/src/Examples/TintColors.tsx
@@ -20,6 +20,7 @@ export default function TintColorsExample() {
       title: 'Albums',
       focusedIcon: require('../../assets/icons/grid_dark.png'),
       badge: '5',
+      activeTintColor: 'green',
     },
     {
       key: 'contacts',
@@ -46,8 +47,8 @@ export default function TintColorsExample() {
       navigationState={{ index, routes }}
       onIndexChange={setIndex}
       renderScene={renderScene}
-      activeTintColor="red"
-      inactiveTintColor="blue"
+      inactiveTintColor="red"
+      scrollEdgeAppearance="default"
     />
   );
 }

--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -8,6 +8,15 @@ extension Collection {
   }
 }
 
+
+extension Collection where Element == TabInfo {
+  func findByKey(_ key: String?) -> Element? {
+    guard let key else { return nil }
+    guard !isEmpty else { return nil }
+    return first(where: { $0.key == key })
+  }
+}
+
 extension UIView {
   func pinEdges(to other: UIView) {
     NSLayoutConstraint.activate([

--- a/ios/RCTTabViewViewManager.mm
+++ b/ios/RCTTabViewViewManager.mm
@@ -34,5 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(disablePageAnimations, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(scrollEdgeAppearance, NSString)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(activeTintColor, NSString)
+RCT_EXPORT_VIEW_PROPERTY(inactiveTintColor, NSString)
 
 @end

--- a/ios/RCTTabViewViewManager.mm
+++ b/ios/RCTTabViewViewManager.mm
@@ -34,7 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(disablePageAnimations, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(scrollEdgeAppearance, NSString)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(activeTintColor, NSString)
-RCT_EXPORT_VIEW_PROPERTY(inactiveTintColor, NSString)
+RCT_EXPORT_VIEW_PROPERTY(activeTintColor, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(inactiveTintColor, NSNumber)
 
 @end

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -17,8 +17,8 @@ class TabViewProps: ObservableObject {
   @Published var scrollEdgeAppearance: String?
   @Published var barTintColor: UIColor?
   @Published var translucent: Bool = true
-  @Published var activeTintColor: Color?
-  @Published var inactiveTintColor: Color?
+  @Published var activeTintColor: UIColor?
+  @Published var inactiveTintColor: UIColor?
 }
 
 /**
@@ -202,8 +202,9 @@ extension View {
   }
 
   @ViewBuilder
-  func tintColor(_ color: Color?) -> some View {
+  func tintColor(_ color: UIColor?) -> some View {
     if let color {
+      let color = Color(color)
       if #available(iOS 16.0, *) {
         self.tint(color)
       } else {

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -210,6 +210,8 @@ extension View {
       } else {
         self.accentColor(color)
       }
+    } else {
+      self
     }
   }
 }

--- a/ios/TabViewProvider.swift
+++ b/ios/TabViewProvider.swift
@@ -7,6 +7,7 @@ struct TabInfo: Codable {
   let title: String
   let badge: String
   let sfSymbol: String
+  let activeTintColor: Int?
 }
 
 struct TabData: Codable {
@@ -168,7 +169,8 @@ struct TabData: Codable {
             key: itemDict["key"] as? String ?? "",
             title: itemDict["title"] as? String ?? "",
             badge: itemDict["badge"] as? String ?? "",
-            sfSymbol: itemDict["sfSymbol"] as? String ?? ""
+            sfSymbol: itemDict["sfSymbol"] as? String ?? "",
+            activeTintColor: itemDict["activeTintColor"] as? Int
           )
         )
       }

--- a/ios/TabViewProvider.swift
+++ b/ios/TabViewProvider.swift
@@ -82,16 +82,16 @@ struct TabData: Codable {
       props.barTintColor = RCTConvert.uiColor(barTintColor)
       }
   }
-  @objc var activeTintColor: NSString? {
+
+  @objc var activeTintColor: NSNumber? {
     didSet {
-      props.activeTintColor = Color(hex: activeTintColor as? String)
+      props.activeTintColor = RCTConvert.uiColor(activeTintColor)
     }
   }
 
-
-  @objc var inactiveTintColor: NSString? {
+  @objc var inactiveTintColor: NSNumber? {
     didSet {
-      props.inactiveTintColor = Color(hex: inactiveTintColor as? String)
+      props.inactiveTintColor = RCTConvert.uiColor(inactiveTintColor)
     }
   }
 
@@ -185,36 +185,5 @@ extension UIImage {
     let resizedImage = UIGraphicsGetImageFromCurrentImageContext()!
     UIGraphicsEndImageContext()
     return resizedImage
-  }
-}
-
-// @see https://stackoverflow.com/a/56874327
-extension Color {
-  init?(hex: String?) {
-    if hex == nil {
-      return nil
-    }
-    let hex = hex!.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-    var int: UInt64 = 0
-    Scanner(string: hex).scanHexInt64(&int)
-    let a, r, g, b: UInt64
-    switch hex.count {
-    case 3: // RGB (12-bit)
-      (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
-    case 6: // RGB (24-bit)
-      (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-    case 8: // ARGB (32-bit)
-      (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
-    default:
-      (a, r, g, b) = (1, 1, 1, 0)
-    }
-
-    self.init(
-      .sRGB,
-      red: Double(r) / 255,
-      green: Double(g) / 255,
-      blue:  Double(b) / 255,
-      opacity: Double(a) / 255
-    )
   }
 }

--- a/ios/TabViewProvider.swift
+++ b/ios/TabViewProvider.swift
@@ -80,6 +80,18 @@ struct TabData: Codable {
   @objc var barTintColor: NSNumber? {
     didSet {
       props.barTintColor = RCTConvert.uiColor(barTintColor)
+      }
+  }
+  @objc var activeTintColor: NSString? {
+    didSet {
+      props.activeTintColor = Color(hex: activeTintColor as? String)
+    }
+  }
+
+
+  @objc var inactiveTintColor: NSString? {
+    didSet {
+      props.inactiveTintColor = Color(hex: inactiveTintColor as? String)
     }
   }
 
@@ -173,5 +185,36 @@ extension UIImage {
     let resizedImage = UIGraphicsGetImageFromCurrentImageContext()!
     UIGraphicsEndImageContext()
     return resizedImage
+  }
+}
+
+// @see https://stackoverflow.com/a/56874327
+extension Color {
+  init?(hex: String?) {
+    if hex == nil {
+      return nil
+    }
+    let hex = hex!.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+    var int: UInt64 = 0
+    Scanner(string: hex).scanHexInt64(&int)
+    let a, r, g, b: UInt64
+    switch hex.count {
+    case 3: // RGB (12-bit)
+      (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+    case 6: // RGB (24-bit)
+      (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+    case 8: // ARGB (32-bit)
+      (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+    default:
+      (a, r, g, b) = (1, 1, 1, 0)
+    }
+
+    self.init(
+      .sRGB,
+      red: Double(r) / 255,
+      green: Double(g) / 255,
+      blue:  Double(b) / 255,
+      opacity: Double(a) / 255
+    )
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@evilmartians/lefthook": "^1.5.0",
     "@react-native/eslint-config": "^0.73.1",
     "@react-navigation/native": "^6.1.18",
+    "@types/color": "^3.0.6",
     "@types/jest": "^29.5.5",
     "@types/react": "^18.2.44",
     "commitlint": "^17.0.2",
@@ -199,6 +200,7 @@
     "version": "0.41.2"
   },
   "dependencies": {
+    "color": "^4.2.3",
     "sf-symbols-typescript": "^2.0.0",
     "use-latest-callback": "^0.2.1"
   }

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -48,6 +48,14 @@ interface Props<Route extends BaseRoute> {
    */
   scrollEdgeAppearance?: 'default' | 'opaque' | 'transparent';
   /**
+   * Active tab color.
+   */
+  activeTintColor?: string;
+  /**
+   * Inactive tab color.
+   */
+  inactiveTintColor?: string;
+  /**
    * State for the tab view.
    *
    * The state should contain a `routes` prop which is an array of objects containing `key` and `title` props, such as `{ key: 'music', title: 'Music' }`.

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -50,11 +50,11 @@ interface Props<Route extends BaseRoute> {
   /**
    * Active tab color.
    */
-  activeTintColor?: ColorValue;
+  tabBarActiveTintColor?: ColorValue;
   /**
    * Inactive tab color.
    */
-  inactiveTintColor?: ColorValue;
+  tabBarInactiveTintColor?: ColorValue;
   /**
    * State for the tab view.
    *
@@ -124,6 +124,9 @@ const TabView = <Route extends BaseRoute>({
       : route.focusedIcon,
   barTintColor,
   getActiveTintColor = ({ route }: { route: Route }) => route.activeTintColor,
+  tabBarActiveTintColor: activeTintColor,
+  tabBarInactiveTintColor: inactiveTintColor,
+  rippleColor,
   ...props
 }: Props<Route>) => {
   // @ts-ignore
@@ -211,9 +214,11 @@ const TabView = <Route extends BaseRoute>({
       onPageSelected={({ nativeEvent: { key } }) => {
         jumpTo(key);
       }}
-      barTintColor={processColor(barTintColor)}
       {...props}
-      rippleColor={processColor(props.rippleColor)}
+      activeTintColor={processColor(activeTintColor)}
+      inactiveTintColor={processColor(inactiveTintColor)}
+      barTintColor={processColor(barTintColor)}
+      rippleColor={processColor(rippleColor)}
     >
       {trimmedRoutes.map((route) => {
         if (getLazy({ route }) !== false && !loaded.includes(route.key)) {

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -174,6 +174,7 @@ const TabView = <Route extends BaseRoute>({
           title: getLabelText({ route }) ?? route.key,
           sfSymbol: isSfSymbol ? icon.sfSymbol : undefined,
           badge: props.getBadge?.({ route }),
+          activeTintColor: processColor(route.activeTintColor),
         };
       }),
     [getLabelText, icons, trimmedRoutes, props]

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -86,6 +86,10 @@ interface Props<Route extends BaseRoute> {
    */
   getBadge?: (props: { route: Route }) => string | undefined;
   /**
+   * Get active tint color for the tab, uses `route.activeTintColor` by default.
+   */
+  getActiveTintColor?: (props: { route: Route }) => ColorValue | undefined;
+  /**
    * Get icon for the tab, uses `route.focusedIcon` by default.
    */
   getIcon?: (props: {
@@ -119,6 +123,7 @@ const TabView = <Route extends BaseRoute>({
         : route.unfocusedIcon
       : route.focusedIcon,
   barTintColor,
+  getActiveTintColor = ({ route }: { route: Route }) => route.activeTintColor,
   ...props
 }: Props<Route>) => {
   // @ts-ignore
@@ -174,10 +179,10 @@ const TabView = <Route extends BaseRoute>({
           title: getLabelText({ route }) ?? route.key,
           sfSymbol: isSfSymbol ? icon.sfSymbol : undefined,
           badge: props.getBadge?.({ route }),
-          activeTintColor: processColor(route.activeTintColor),
+          activeTintColor: processColor(getActiveTintColor({ route })),
         };
       }),
-    [getLabelText, icons, trimmedRoutes, props]
+    [trimmedRoutes, icons, getLabelText, props, getActiveTintColor]
   );
 
   const resolvedIconAssets: ImageSource[] = useMemo(

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -50,11 +50,11 @@ interface Props<Route extends BaseRoute> {
   /**
    * Active tab color.
    */
-  activeTintColor?: string;
+  activeTintColor?: ColorValue;
   /**
    * Inactive tab color.
    */
-  inactiveTintColor?: string;
+  inactiveTintColor?: ColorValue;
   /**
    * State for the tab view.
    *

--- a/src/TabViewAdapter.android.tsx
+++ b/src/TabViewAdapter.android.tsx
@@ -1,12 +1,22 @@
 import NativeTabView from './TabViewNativeComponent';
-import type { TabViewProps } from './TabViewNativeComponent';
-import { StyleSheet, View } from 'react-native';
+import type { TabViewNativeProps } from './TabViewNativeComponent';
+import { processColor, StyleSheet, View } from 'react-native';
 
-const TabViewAdapter = ({ children, ...props }: TabViewProps) => {
+const TabViewAdapter = ({
+  children,
+  activeTintColor,
+  inactiveTintColor,
+  ...props
+}: TabViewNativeProps) => {
   return (
     <>
       <View style={styles.content}>{children}</View>
-      <NativeTabView {...props} style={styles.tabBar} />
+      <NativeTabView
+        {...props}
+        activeTintColor={processColor(activeTintColor)}
+        inactiveTintColor={processColor(inactiveTintColor)}
+        style={styles.tabBar}
+      />
     </>
   );
 };

--- a/src/TabViewAdapter.android.tsx
+++ b/src/TabViewAdapter.android.tsx
@@ -1,22 +1,12 @@
 import NativeTabView from './TabViewNativeComponent';
-import type { TabViewNativeProps } from './TabViewNativeComponent';
-import { processColor, StyleSheet, View } from 'react-native';
+import type { TabViewProps } from './TabViewNativeComponent';
+import { StyleSheet, View } from 'react-native';
 
-const TabViewAdapter = ({
-  children,
-  activeTintColor,
-  inactiveTintColor,
-  ...props
-}: TabViewNativeProps) => {
+const TabViewAdapter = ({ children, ...props }: TabViewProps) => {
   return (
     <>
       <View style={styles.content}>{children}</View>
-      <NativeTabView
-        {...props}
-        activeTintColor={processColor(activeTintColor)}
-        inactiveTintColor={processColor(inactiveTintColor)}
-        style={styles.tabBar}
-      />
+      <NativeTabView {...props} style={styles.tabBar} />
     </>
   );
 };

--- a/src/TabViewAdapter.tsx
+++ b/src/TabViewAdapter.tsx
@@ -1,18 +1,7 @@
-import { processColor } from 'react-native';
-import NativeTabView, { TabViewNativeProps } from './TabViewNativeComponent';
+import NativeTabView, { TabViewProps } from './TabViewNativeComponent';
 
-const TabViewAdapter = ({
-  activeTintColor,
-  inactiveTintColor,
-  ...props
-}: TabViewNativeProps) => {
-  return (
-    <NativeTabView
-      {...props}
-      activeTintColor={processColor(activeTintColor)}
-      inactiveTintColor={processColor(inactiveTintColor)}
-    />
-  );
+const TabViewAdapter = (props: TabViewProps) => {
+  return <NativeTabView {...props} />;
 };
 
 export default TabViewAdapter;

--- a/src/TabViewAdapter.tsx
+++ b/src/TabViewAdapter.tsx
@@ -1,7 +1,18 @@
-import NativeTabView, { type TabViewProps } from './TabViewNativeComponent';
+import { processColor } from 'react-native';
+import NativeTabView, { TabViewNativeProps } from './TabViewNativeComponent';
 
-const TabViewAdapter = ({ ...props }: TabViewProps) => {
-  return <NativeTabView {...props} />;
+const TabViewAdapter = ({
+  activeTintColor,
+  inactiveTintColor,
+  ...props
+}: TabViewNativeProps) => {
+  return (
+    <NativeTabView
+      {...props}
+      activeTintColor={processColor(activeTintColor)}
+      inactiveTintColor={processColor(inactiveTintColor)}
+    />
+  );
 };
 
 export default TabViewAdapter;

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -1,5 +1,5 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ColorValue, ProcessedColorValue, ViewProps } from 'react-native';
+import type { ProcessedColorValue, ViewProps } from 'react-native';
 import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 //@ts-ignore
 import type { ImageSource } from 'react-native/Libraries/Image/ImageSource';
@@ -30,13 +30,5 @@ export interface TabViewProps extends ViewProps {
   activeTintColor?: ProcessedColorValue | null;
   inactiveTintColor?: ProcessedColorValue | null;
 }
-
-export type TabViewNativeProps = Omit<
-  TabViewProps,
-  'activeTintColor' | 'inactiveTintColor'
-> & {
-  activeTintColor?: ColorValue;
-  inactiveTintColor?: ColorValue;
-};
 
 export default codegenNativeComponent<TabViewProps>('RCTTabView');

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -1,5 +1,5 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ProcessedColorValue } from 'react-native';
+import type { ColorValue, ProcessedColorValue, ViewProps } from 'react-native';
 import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 //@ts-ignore
 import type { ImageSource } from 'react-native/Libraries/Image/ImageSource';
@@ -26,8 +26,16 @@ export interface TabViewProps extends ViewProps {
   barTintColor?: ProcessedColorValue | null;
   translucent?: boolean;
   rippleColor?: ProcessedColorValue | null;
-  activeTintColor?: string;
-  inactiveTintColor?: string;
+  activeTintColor?: ProcessedColorValue | null;
+  inactiveTintColor?: ProcessedColorValue | null;
 }
+
+export type TabViewNativeProps = Omit<
+  TabViewProps,
+  'activeTintColor' | 'inactiveTintColor'
+> & {
+  activeTintColor?: ColorValue;
+  inactiveTintColor?: ColorValue;
+};
 
 export default codegenNativeComponent<TabViewProps>('RCTTabView');

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -13,6 +13,7 @@ export type TabViewItems = ReadonlyArray<{
   title: string;
   sfSymbol?: string;
   badge?: string;
+  activeTintColor?: ProcessedColorValue | null;
 }>;
 
 export interface TabViewProps extends ViewProps {

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -26,6 +26,8 @@ export interface TabViewProps extends ViewProps {
   barTintColor?: ProcessedColorValue | null;
   translucent?: boolean;
   rippleColor?: ProcessedColorValue | null;
+  activeTintColor?: string;
+  inactiveTintColor?: string;
 }
 
 export default codegenNativeComponent<TabViewProps>('RCTTabView');

--- a/src/react-navigation/navigators/createNativeBottomTabNavigator.tsx
+++ b/src/react-navigation/navigators/createNativeBottomTabNavigator.tsx
@@ -9,7 +9,9 @@ import {
   TabRouter,
   createNavigatorFactory,
   useNavigationBuilder,
+  useTheme,
 } from '@react-navigation/native';
+import Color from 'color';
 
 import type {
   NativeBottomTabNavigationConfig,
@@ -34,8 +36,21 @@ function NativeBottomTabNavigator({
   children,
   screenListeners,
   screenOptions,
+  activeTintColor: customActiveTintColor,
+  inactiveTintColor: customInactiveTintColor,
   ...rest
 }: NativeBottomTabNavigatorProps) {
+  const { colors } = useTheme();
+  const activeTintColor =
+    customActiveTintColor === undefined
+      ? colors.primary
+      : customActiveTintColor;
+
+  const inactiveTintColor =
+    customInactiveTintColor === undefined
+      ? Color(colors.text).mix(Color(colors.card), 0.5).hex()
+      : customInactiveTintColor;
+
   const { state, descriptors, navigation, NavigationContent } =
     useNavigationBuilder<
       TabNavigationState<ParamListBase>,
@@ -56,6 +71,8 @@ function NativeBottomTabNavigator({
     <NavigationContent>
       <NativeBottomTabView
         {...rest}
+        activeTintColor={activeTintColor}
+        inactiveTintColor={inactiveTintColor}
         state={state}
         navigation={navigation}
         descriptors={descriptors}

--- a/src/react-navigation/navigators/createNativeBottomTabNavigator.tsx
+++ b/src/react-navigation/navigators/createNativeBottomTabNavigator.tsx
@@ -36,8 +36,8 @@ function NativeBottomTabNavigator({
   children,
   screenListeners,
   screenOptions,
-  activeTintColor: customActiveTintColor,
-  inactiveTintColor: customInactiveTintColor,
+  tabBarActiveTintColor: customActiveTintColor,
+  tabBarInactiveTintColor: customInactiveTintColor,
   ...rest
 }: NativeBottomTabNavigatorProps) {
   const { colors } = useTheme();
@@ -71,8 +71,8 @@ function NativeBottomTabNavigator({
     <NavigationContent>
       <NativeBottomTabView
         {...rest}
-        activeTintColor={activeTintColor}
-        inactiveTintColor={inactiveTintColor}
+        tabBarActiveTintColor={activeTintColor}
+        tabBarInactiveTintColor={inactiveTintColor}
         state={state}
         navigation={navigation}
         descriptors={descriptors}

--- a/src/react-navigation/types.ts
+++ b/src/react-navigation/types.ts
@@ -72,6 +72,11 @@ export type NativeBottomTabNavigationOptions = {
    * Whether this screens should render the first time it's accessed. Defaults to true. Set it to false if you want to render the screen on initial render.
    */
   lazy?: boolean;
+
+  /**
+   * Active tab color.
+   */
+  tabBarActiveTintColor?: string;
 };
 
 export type NativeBottomTabDescriptor = Descriptor<
@@ -95,5 +100,6 @@ export type NativeBottomTabNavigationConfig = Partial<
     | 'getIcon'
     | 'getLabelText'
     | 'getBadge'
+    | 'getActiveTintColor'
   >
 >;

--- a/src/react-navigation/views/NativeBottomTabView.tsx
+++ b/src/react-navigation/views/NativeBottomTabView.tsx
@@ -27,6 +27,9 @@ export default function NativeBottomTabView({
       {...rest}
       navigationState={state}
       renderScene={({ route }) => descriptors[route.key]?.render()}
+      getActiveTintColor={({ route }) => {
+        return descriptors[route.key]?.options.tabBarActiveTintColor;
+      }}
       getLabelText={({ route }) => {
         const options = descriptors[route.key]?.options;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type BaseRoute = {
   lazy?: boolean;
   focusedIcon?: ImageSourcePropType | AppleIcon;
   unfocusedIcon?: ImageSourcePropType | AppleIcon;
+  activeTintColor?: string;
 };
 
 export type NavigationState<Route extends BaseRoute> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4296,6 +4296,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/color-convert@npm:*":
+  version: 2.0.4
+  resolution: "@types/color-convert@npm:2.0.4"
+  dependencies:
+    "@types/color-name": ^1.1.0
+  checksum: 694141a03d6dbddbe57dea71a45db89799a0a352516bbafbcc54dff6321734c6838f60672119e1d586043a9d1fcd220226ea9db7f296c1c08ffdaa04d613a83b
+  languageName: node
+  linkType: hard
+
+"@types/color-name@npm:^1.1.0":
+  version: 1.1.5
+  resolution: "@types/color-name@npm:1.1.5"
+  checksum: ea889762fb0fbe1df5931d2b058316b2ad1209257dc8b9a3871c554fdf2f2ad28b610f5362d9dc449f699495e83206cd2889dfcbdc10bbf7fd84cc51c4b3c5be
+  languageName: node
+  linkType: hard
+
+"@types/color@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@types/color@npm:3.0.6"
+  dependencies:
+    "@types/color-convert": "*"
+  checksum: 0f16dcf4e202896d5425019c44a1f99713fca998052ab2fd836cdd38048398a0caf5b79a2efe560e41fca4b9401e8d8f6f02ed541cfea30cca3a8cb1b50b80f7
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
@@ -13562,8 +13587,10 @@ __metadata:
     "@evilmartians/lefthook": ^1.5.0
     "@react-native/eslint-config": ^0.73.1
     "@react-navigation/native": ^6.1.18
+    "@types/color": ^3.0.6
     "@types/jest": ^29.5.5
     "@types/react": ^18.2.44
+    color: ^4.2.3
     commitlint: ^17.0.2
     del-cli: ^5.1.0
     eslint: ^8.51.0


### PR DESCRIPTION
### PR Description:
This pull request introduces a new feature that adds support for active/inactive tint colors on tabs across both Android and iOS components.

### Notes:
- **Color Handling:**  
  The colors are sourced from the `react-navigation` theme by default. This follows the same approach used by `@react-navigation/bottom-tabs`. As a result, I added dependencies for `color` and `@types/color` to handle this functionality.

- **Android Implementation:**  
  My Kotlin code might feel more Java-like, as I'm more familiar with Java. So, you’ll notice some usage of `as` and `if (x != null)` for type narrowing.

- **iOS Implementation:**  
  As you may know, SwiftUI Tabs rely on the appearance of the UIKit tab bar. However, SwiftUI doesn't provide a built-in way to customize the inactive (unselected) tint color. To work around this, I had to leverage the UIKit appearance settings.
