### PR TITLE
fix: add react-navigation export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,16 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
+    },
+    "./react-navigation": {
+      "import": {
+        "types": "./lib/typescript/module/src/react-navigation/index.d.ts",
+        "default": "./lib/module/react-navigation/index.js"
+      },
+      "require": {
+        "types": "./lib/typescript/commonjs/src/react-navigation/index.d.ts",
+        "default": "./lib/commonjs/react-navigation/index.js"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
Yo! Awesome work with this library, was testing it out with onestack.dev and this makes things a bit easier to set up with Vite.