### PR TITLE
fix: docs link target in header

### DIFF
--- a/docs/docs/_meta.json
+++ b/docs/docs/_meta.json
@@ -1,7 +1,7 @@
 [
   {
     "text": "Docs",
-    "link": "/docs/",
-    "activeMatch": "/docs/"
+    "link": "/docs/getting-started/quick-start",
+    "activeMatch": "^/docs/"
   }
 ]


### PR DESCRIPTION
fixed a link in the header based on config in Re.Pack [here](https://github.com/callstack/repack/blob/main/website/src/4.x/_meta.json)