### PR TITLE
feat(iOS): scroll edge appearance

### DIFF
--- a/docs/docs/docs/guides/usage-with-react-navigation.md
+++ b/docs/docs/docs/guides/usage-with-react-navigation.md
@@ -55,6 +55,15 @@ Whether to show labels in tabs. Defaults to true.
 
 Whether to disable page animations between tabs. (iOS only)
 
+#### `scrollEdgeAppearance`
+
+Describes the appearance attributes for the tabBar to use when an observable scroll view is scrolled to the bottom. (iOS only)
+
+Available options:
+- `default` - uses default background and shadow values.
+- `transparent` - uses transparent background and no shadow.
+- `opaque` - uses set of opaque colors that are appropriate for the current theme
+
 #### `sidebarAdaptable`
 
 A tab bar style that adapts to each platform. (Apple platforms only)

--- a/docs/docs/docs/guides/usage-with-react-navigation.md
+++ b/docs/docs/docs/guides/usage-with-react-navigation.md
@@ -64,6 +64,7 @@ Available options:
 - `transparent` - uses transparent background and no shadow.
 - `opaque` - uses set of opaque colors that are appropriate for the current theme
 
+Note: It's recommended to use `transparent` or `opaque` without lazy loading as the tab bar background flashes when a view is rendered lazily.
 #### `sidebarAdaptable`
 
 A tab bar style that adapts to each platform. (Apple platforms only)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -31,6 +31,10 @@ const FourTabsNoAnimations = () => {
   return <FourTabs disablePageAnimations />;
 };
 
+const FourTabsTransparentScrollEdgeAppearance = () => {
+  return <FourTabs scrollEdgeAppearance="transparent" />;
+};
+
 const examples = [
   { component: ThreeTabs, name: 'Three Tabs' },
   { component: FourTabs, name: 'Four Tabs' },
@@ -42,6 +46,10 @@ const examples = [
     screenOptions: { headerShown: false },
   },
   { component: FourTabsNoAnimations, name: 'Four Tabs - no animations' },
+  {
+    component: FourTabsTransparentScrollEdgeAppearance,
+    name: 'Four Tabs - Transparent scroll edge appearance',
+  },
   { component: NativeBottomTabs, name: 'Native Bottom Tabs' },
   { component: JSBottomTabs, name: 'JS Bottom Tabs' },
   {

--- a/example/src/Examples/FourTabs.tsx
+++ b/example/src/Examples/FourTabs.tsx
@@ -8,11 +8,13 @@ import { Chat } from '../Screens/Chat';
 interface Props {
   ignoresTopSafeArea?: boolean;
   disablePageAnimations?: boolean;
+  scrollEdgeAppearance?: 'default' | 'opaque' | 'transparent';
 }
 
 export default function FourTabs({
   ignoresTopSafeArea = false,
   disablePageAnimations = false,
+  scrollEdgeAppearance = 'default',
 }: Props) {
   const [index, setIndex] = useState(0);
   const [routes] = useState([
@@ -53,6 +55,7 @@ export default function FourTabs({
       ignoresTopSafeArea={ignoresTopSafeArea}
       sidebarAdaptable
       disablePageAnimations={disablePageAnimations}
+      scrollEdgeAppearance={scrollEdgeAppearance}
       navigationState={{ index, routes }}
       onIndexChange={setIndex}
       renderScene={renderScene}

--- a/ios/RCTTabViewViewManager.mm
+++ b/ios/RCTTabViewViewManager.mm
@@ -31,5 +31,6 @@ RCT_EXPORT_VIEW_PROPERTY(sidebarAdaptable, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(labeled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(ignoresTopSafeArea, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(disablePageAnimations, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(scrollEdgeAppearance, NSString)
 
 @end

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -14,6 +14,7 @@ class TabViewProps: ObservableObject {
   @Published var labeled: Bool?
   @Published var ignoresTopSafeArea: Bool?
   @Published var disablePageAnimations: Bool = false
+  @Published var scrollEdgeAppearance: String?
 }
 
 /**
@@ -70,14 +71,28 @@ struct TabViewImpl: View {
       }
       onSelect(newValue)
     }
-    .onAppear {
+    .onChange(of: props.scrollEdgeAppearance) { newValue in
       if #available(iOS 15.0, *) {
         // This causes issues with lazy loading making the TabView background blink.
-        let appearance = UITabBarAppearance()
-        UITabBar.appearance().scrollEdgeAppearance = appearance
+        UITabBar.appearance().scrollEdgeAppearance = configureAppearance(for: newValue ?? "")
       }
     }
   }
+}
+
+private func configureAppearance(for appearanceType: String) -> UITabBarAppearance {
+  let appearance = UITabBarAppearance()
+  
+  switch appearanceType {
+  case "opaque":
+    appearance.configureWithOpaqueBackground()
+  case "transparent":
+    appearance.configureWithTransparentBackground()
+  default:
+    appearance.configureWithDefaultBackground()
+  }
+  
+  return appearance
 }
 
 struct TabItem: View {

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -73,7 +73,6 @@ struct TabViewImpl: View {
     }
     .onChange(of: props.scrollEdgeAppearance) { newValue in
       if #available(iOS 15.0, *) {
-        // This causes issues with lazy loading making the TabView background blink.
         UITabBar.appearance().scrollEdgeAppearance = configureAppearance(for: newValue ?? "")
       }
     }

--- a/ios/TabViewProvider.swift
+++ b/ios/TabViewProvider.swift
@@ -59,6 +59,12 @@ struct TabData: Codable {
     }
   }
   
+  @objc var scrollEdgeAppearance: NSString? {
+    didSet {
+      props.scrollEdgeAppearance = scrollEdgeAppearance as? String
+    }
+  }
+  
   @objc var items: NSArray? {
     didSet {
       props.items = parseTabData(from: items)

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -37,6 +37,10 @@ interface Props<Route extends BaseRoute> {
    */
   disablePageAnimations?: boolean;
   /**
+   * Describes the appearance attributes for the tabBar to use when an observable scroll view is scrolled to the bottom. (iOS only)
+   */
+  scrollEdgeAppearance?: 'default' | 'opaque' | 'transparent';
+  /**
    * State for the tab view.
    *
    * The state should contain a `routes` prop which is an array of objects containing `key` and `title` props, such as `{ key: 'music', title: 'Music' }`.

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -22,6 +22,7 @@ export interface TabViewProps extends ViewProps {
   icons?: ReadonlyArray<ImageSource>;
   labeled?: boolean;
   sidebarAdaptable?: boolean;
+  scrollEdgeAppearance?: string;
 }
 
 export default codegenNativeComponent<TabViewProps>('RCTTabView');


### PR DESCRIPTION
This let's you define the edge appearance of the tabbar.
Allowing for a tabbar that is transparent when there is no content behind the tabbar.

@okwasniewski I am a bit in doubt what we should initially set this to... It seems that if you have a tabbarcontroller it modifies this to transparent by default? Do we want it transparent by default (on the scroll edge) or not... hmm...

_If the value of this property is nil, UIKit uses the value of the tab bar’s [standardAppearance](https://developer.apple.com/documentation/uikit/uitabbar/3198046-standardappearance) property, modified to have a transparent background. If no tab bar controller manages your tab bar, UIKit ignores this property and uses the tab bar’s standard appearance._