### PR TITLE
Added support for barTintColor in android ios

### DIFF
--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -145,10 +145,6 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   }
 
   fun setBarTintColor(color: Int?) {
-    updateBackgroundColors(color)
-  }
-
-  private fun updateBackgroundColors(color: Int?) {
     // Set the color, either using the active background color or a default color.
     val backgroundColor = color ?: getDefaultColorFor(android.R.attr.colorPrimary) ?: return
 
@@ -157,7 +153,6 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
 
     itemBackground = colorDrawable
   }
-
 
   private fun getDefaultColorFor(baseColorThemeAttr: Int): Int? {
     val value = TypedValue()

--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -28,7 +28,6 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   var items: MutableList<TabInfo>? = null
   var onTabSelectedListener: ((WritableMap) -> Unit)? = null
   private var isAnimating = false
-  private var barTintColor : Int? = null
 
   private val layoutCallback = Choreographer.FrameCallback {
     isLayoutEnqueued = false
@@ -146,13 +145,12 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   }
 
   fun setBarTintColor(color: Int?) {
-    barTintColor = color
-    updateBackgroundColors()
+    updateBackgroundColors(color)
   }
 
-  private fun updateBackgroundColors() {
+  private fun updateBackgroundColors(color: Int?) {
     // Set the color, either using the active background color or a default color.
-    val backgroundColor = barTintColor ?: getDefaultColorFor(android.R.attr.colorPrimary) ?: return
+    val backgroundColor = color ?: getDefaultColorFor(android.R.attr.colorPrimary) ?: return
 
     // Apply the same color to both active and inactive states
     val colorDrawable = ColorDrawable(backgroundColor)

--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -2,10 +2,13 @@ package com.rcttabview
 
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
+import android.util.TypedValue
 import android.net.Uri
 import android.view.Choreographer
 import android.view.MenuItem
+import androidx.appcompat.content.res.AppCompatResources
 import com.facebook.common.references.CloseableReference
 import com.facebook.datasource.DataSources
 import com.facebook.drawee.backends.pipeline.Fresco
@@ -25,6 +28,7 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   var items: MutableList<TabInfo>? = null
   var onTabSelectedListener: ((WritableMap) -> Unit)? = null
   private var isAnimating = false
+  private var barTintColor : Int? = null
 
   private val layoutCallback = Choreographer.FrameCallback {
     isLayoutEnqueued = false
@@ -139,5 +143,30 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
     isAnimating = false
+  }
+
+  fun setBarTintColor(color: Int?) {
+    barTintColor = color
+    updateBackgroundColors()
+  }
+
+  private fun updateBackgroundColors() {
+    // Set the color, either using the active background color or a default color.
+    val backgroundColor = barTintColor ?: getDefaultColorFor(android.R.attr.colorPrimary) ?: return
+
+    // Apply the same color to both active and inactive states
+    val colorDrawable = ColorDrawable(backgroundColor)
+
+    itemBackground = colorDrawable
+  }
+
+
+  private fun getDefaultColorFor(baseColorThemeAttr: Int): Int? {
+    val value = TypedValue()
+    if (!context.theme.resolveAttribute(baseColorThemeAttr, value, true)) {
+      return null
+    }
+    val baseColor = AppCompatResources.getColorStateList(context, value.resourceId)
+    return baseColor.defaultColor
   }
 }

--- a/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
@@ -67,6 +67,11 @@ class RCTTabViewViewManager :
     view.setIcons(icons)
   }
 
+  @ReactProp(name = "barTintColor")
+  fun setBarTintColor(view: ReactBottomNavigationView, color: Int?) {
+    view.setBarTintColor(color)
+  }
+
   public override fun createViewInstance(context: ThemedReactContext): ReactBottomNavigationView {
     eventDispatcher = context.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher
     val view = ReactBottomNavigationView(context)

--- a/docs/docs/docs/guides/usage-with-react-navigation.md
+++ b/docs/docs/docs/guides/usage-with-react-navigation.md
@@ -51,6 +51,10 @@ Default options to use for the screens in the navigator.
 
 Whether to show labels in tabs. Defaults to true.
 
+#### `barTintColor`
+
+Background color of the tab bar.
+
 #### `disablePageAnimations`
 
 Whether to disable page animations between tabs. (iOS only)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -36,7 +36,7 @@ const FourTabsTransparentScrollEdgeAppearance = () => {
 };
 
 const FourTabsWithBarTintColor = () => {
-  return <FourTabs barTintColor={''} />;
+  return <FourTabs barTintColor={'#87CEEB'} />;
 };
 
 const examples = [

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -35,6 +35,10 @@ const FourTabsTransparentScrollEdgeAppearance = () => {
   return <FourTabs scrollEdgeAppearance="transparent" />;
 };
 
+const FourTabsWithBarTintColor = () => {
+  return <FourTabs barTintColor={''} />;
+};
+
 const examples = [
   { component: ThreeTabs, name: 'Three Tabs' },
   { component: FourTabs, name: 'Four Tabs' },
@@ -49,6 +53,10 @@ const examples = [
   {
     component: FourTabsTransparentScrollEdgeAppearance,
     name: 'Four Tabs - Transparent scroll edge appearance',
+  },
+  {
+    component: FourTabsWithBarTintColor,
+    name: 'Four Tabs - Custom Background Color of Tabs',
   },
   { component: NativeBottomTabs, name: 'Native Bottom Tabs' },
   { component: JSBottomTabs, name: 'JS Bottom Tabs' },

--- a/example/src/Examples/FourTabs.tsx
+++ b/example/src/Examples/FourTabs.tsx
@@ -4,17 +4,20 @@ import { Article } from '../Screens/Article';
 import { Albums } from '../Screens/Albums';
 import { Contacts } from '../Screens/Contacts';
 import { Chat } from '../Screens/Chat';
+import { ColorValue } from 'react-native';
 
 interface Props {
   ignoresTopSafeArea?: boolean;
   disablePageAnimations?: boolean;
   scrollEdgeAppearance?: 'default' | 'opaque' | 'transparent';
+  barTintColor?: ColorValue;
 }
 
 export default function FourTabs({
   ignoresTopSafeArea = false,
   disablePageAnimations = false,
   scrollEdgeAppearance = 'default',
+  barTintColor,
 }: Props) {
   const [index, setIndex] = useState(0);
   const [routes] = useState([
@@ -59,6 +62,7 @@ export default function FourTabs({
       navigationState={{ index, routes }}
       onIndexChange={setIndex}
       renderScene={renderScene}
+      barTintColor={barTintColor}
     />
   );
 }

--- a/ios/RCTTabViewViewManager.mm
+++ b/ios/RCTTabViewViewManager.mm
@@ -32,5 +32,6 @@ RCT_EXPORT_VIEW_PROPERTY(labeled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(ignoresTopSafeArea, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(disablePageAnimations, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(scrollEdgeAppearance, NSString)
+RCT_EXPORT_VIEW_PROPERTY(barTintColor, NSNumber)
 
 @end

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -15,6 +15,7 @@ class TabViewProps: ObservableObject {
   @Published var ignoresTopSafeArea: Bool?
   @Published var disablePageAnimations: Bool = false
   @Published var scrollEdgeAppearance: String?
+  @Published var barTintColor: UIColor?
 }
 
 /**
@@ -76,6 +77,9 @@ struct TabViewImpl: View {
         UITabBar.appearance().scrollEdgeAppearance = configureAppearance(for: newValue ?? "")
       }
     }
+    .onAppear {
+        updateTabBarAppearance(with: props.barTintColor)
+    }
   }
 }
 
@@ -92,6 +96,20 @@ private func configureAppearance(for appearanceType: String) -> UITabBarAppearan
   }
   
   return appearance
+}
+
+// Helper function to update the tab bar appearance
+private func updateTabBarAppearance(with barTintColor: UIColor?) {
+    
+  if #available(iOS 15.0, *) {
+    let appearance = UITabBarAppearance()
+      
+    appearance.backgroundColor = barTintColor
+    UITabBar.appearance().standardAppearance = appearance
+    UITabBar.appearance().scrollEdgeAppearance = appearance
+  } else {
+    UITabBar.appearance().barTintColor = barTintColor
+  }
 }
 
 struct TabItem: View {

--- a/ios/TabViewProvider.swift
+++ b/ios/TabViewProvider.swift
@@ -70,6 +70,12 @@ struct TabData: Codable {
       props.items = parseTabData(from: items)
     }
   }
+
+  @objc var barTintColor: NSNumber? {
+    didSet {
+      props.barTintColor = RCTConvert.uiColor(barTintColor)
+    }
+  }
   
   @objc public convenience init(eventDispatcher: RCTEventDispatcherProtocol, imageLoader: RCTImageLoader) {
     self.init()

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -1,5 +1,12 @@
 import type { TabViewItems } from './TabViewNativeComponent';
-import { Image, Platform, StyleSheet, View } from 'react-native';
+import {
+  ColorValue,
+  Image,
+  Platform,
+  StyleSheet,
+  View,
+  processColor,
+} from 'react-native';
 
 //@ts-ignore
 import type { ImageSource } from 'react-native/Libraries/Image/ImageSource';
@@ -77,6 +84,11 @@ interface Props<Route extends BaseRoute> {
     route: Route;
     focused: boolean;
   }) => ImageSource | undefined;
+
+  /**
+   * Background color of the tab bar.
+   */
+  barTintColor?: ColorValue;
 }
 
 const ANDROID_MAX_TABS = 6;
@@ -93,6 +105,7 @@ const TabView = <Route extends BaseRoute>({
         ? route.focusedIcon
         : route.unfocusedIcon
       : route.focusedIcon,
+  barTintColor,
   ...props
 }: Props<Route>) => {
   // @ts-ignore
@@ -179,6 +192,7 @@ const TabView = <Route extends BaseRoute>({
       onPageSelected={({ nativeEvent: { key } }) => {
         jumpTo(key);
       }}
+      barTintColor={processColor(barTintColor)}
       {...props}
     >
       {trimmedRoutes.map((route) => {

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -1,5 +1,5 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps } from 'react-native';
+import type { ProcessedColorValue, ViewProps } from 'react-native';
 import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 //@ts-ignore
 import type { ImageSource } from 'react-native/Libraries/Image/ImageSource';
@@ -23,6 +23,7 @@ export interface TabViewProps extends ViewProps {
   labeled?: boolean;
   sidebarAdaptable?: boolean;
   scrollEdgeAppearance?: string;
+  barTintColor?: ProcessedColorValue | null;
 }
 
 export default codegenNativeComponent<TabViewProps>('RCTTabView');


### PR DESCRIPTION
Part of this: https://github.com/okwasniewski/react-native-bottom-tabs/issues/11

**Summary:** This PR updates the tab bar background color for both iOS and Android implementations.

**Changes Made:**

**iOS**: Added the updateTabBarAppearance(with:) function to set the background color using UITabBarAppearance for iOS 15 and barTintColor for earlier versions

**Android**: Updated the tab bar background color to apply uniformly.

**Testing:**

- Verified background color changes on both iOS and Android.
- Added `FourTabsWithBarTintColor` for visual changes.

Adding snapshot of changes here:

iOS:
![simulator_screenshot_6FD154D1-C2C9-4DD2-B6E9-50B27E680B62](https://github.com/user-attachments/assets/db9f3f4e-3e13-4419-8c68-90e8d3cb9d31)

Android:
![Screenshot_20241018_142226](https://github.com/user-attachments/assets/9a80c40f-a6ce-4b40-89d8-e70bea4239d8)
