### PR TITLE
Added support for rippleColor in android

### DIFF
--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -124,7 +124,7 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
       LABEL_VISIBILITY_AUTO
     }
   }
-  fun setRippleColor(color: ColorStateList){
+  fun setRippleColor(color: ColorStateList) {
     itemRippleColor = color
   }
 

--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -75,7 +75,7 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
 
   fun updateItems(items: MutableList<TabInfo>) {
     this.items = items
-    items.forEachIndexed {index, item ->
+    items.forEachIndexed { index, item ->
       val menuItem = getOrCreateItem(index, item.title)
       if (icons.containsKey(index)) {
         menuItem.icon = getDrawable(icons[index]!!)
@@ -124,6 +124,7 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
       LABEL_VISIBILITY_AUTO
     }
   }
+
   fun setRippleColor(color: ColorStateList) {
     itemRippleColor = color
   }

--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -1,6 +1,8 @@
 package com.rcttabview
 
 import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
@@ -121,6 +123,9 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
     } else {
       LABEL_VISIBILITY_AUTO
     }
+  }
+  fun setRippleColor(color: ColorStateList){
+    itemRippleColor = color
   }
 
   private fun getDrawable(imageSource: ImageSource): Drawable {

--- a/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
@@ -1,5 +1,7 @@
 package com.rcttabview
 
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.view.View.MeasureSpec
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.MapBuilder
@@ -65,6 +67,13 @@ class RCTTabViewViewManager :
   @ReactProp(name = "icons")
   fun setIcons(view: ReactBottomNavigationView, icons: ReadableArray?) {
     view.setIcons(icons)
+  }
+  @ReactProp(name = "rippleColor")
+  fun setRippleColor(view: ReactBottomNavigationView, rippleColor: Int?){
+    if(rippleColor!=null) {
+      val color = ColorStateList.valueOf(rippleColor)
+      view.setRippleColor(color)
+    }
   }
 
   public override fun createViewInstance(context: ThemedReactContext): ReactBottomNavigationView {

--- a/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
@@ -38,13 +38,13 @@ class RCTTabViewViewManager :
     val itemsArray = mutableListOf<TabInfo>()
     for (i in 0 until items.size()) {
       items.getMap(i).let { item ->
-          itemsArray.add(
-            TabInfo(
-              key = item.getString("key") ?: "",
-              title = item.getString("title") ?: "",
-              badge = item.getString("badge") ?: ""
-            )
+        itemsArray.add(
+          TabInfo(
+            key = item.getString("key") ?: "",
+            title = item.getString("title") ?: "",
+            badge = item.getString("badge") ?: ""
           )
+        )
       }
     }
     view.updateItems(itemsArray)
@@ -58,7 +58,6 @@ class RCTTabViewViewManager :
   }
 
 
-
   @ReactProp(name = "labeled")
   fun setLabeled(view: ReactBottomNavigationView, flag: Boolean?) {
     view.setLabeled(flag)
@@ -68,9 +67,10 @@ class RCTTabViewViewManager :
   fun setIcons(view: ReactBottomNavigationView, icons: ReadableArray?) {
     view.setIcons(icons)
   }
+
   @ReactProp(name = "rippleColor")
   fun setRippleColor(view: ReactBottomNavigationView, rippleColor: Int?) {
-    if(rippleColor!=null) {
+    if (rippleColor != null) {
       val color = ColorStateList.valueOf(rippleColor)
       view.setRippleColor(color)
     }
@@ -81,7 +81,7 @@ class RCTTabViewViewManager :
     val view = ReactBottomNavigationView(context)
     view.onTabSelectedListener = { data ->
       data.getString("key")?.let {
-        eventDispatcher.dispatchEvent(PageSelectedEvent(viewTag = view.id, key = it ))
+        eventDispatcher.dispatchEvent(PageSelectedEvent(viewTag = view.id, key = it))
       }
     }
     return view
@@ -142,11 +142,14 @@ class RCTTabViewViewManager :
   // iOS Props
 
   @ReactProp(name = "sidebarAdaptable")
-  fun setSidebarAdaptable(view: ReactBottomNavigationView, flag: Boolean) {}
+  fun setSidebarAdaptable(view: ReactBottomNavigationView, flag: Boolean) {
+  }
 
   @ReactProp(name = "ignoresTopSafeArea")
-  fun setIgnoresTopSafeArea(view: ReactBottomNavigationView, flag: Boolean) {}
+  fun setIgnoresTopSafeArea(view: ReactBottomNavigationView, flag: Boolean) {
+  }
 
   @ReactProp(name = "disablePageAnimations")
-  fun setDisablePageAnimations(view: ReactBottomNavigationView, flag: Boolean) {}
+  fun setDisablePageAnimations(view: ReactBottomNavigationView, flag: Boolean) {
+  }
 }

--- a/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabViewViewManager.kt
@@ -69,7 +69,7 @@ class RCTTabViewViewManager :
     view.setIcons(icons)
   }
   @ReactProp(name = "rippleColor")
-  fun setRippleColor(view: ReactBottomNavigationView, rippleColor: Int?){
+  fun setRippleColor(view: ReactBottomNavigationView, rippleColor: Int?) {
     if(rippleColor!=null) {
       val color = ColorStateList.valueOf(rippleColor)
       view.setRippleColor(color)

--- a/docs/docs/docs/guides/usage-with-react-navigation.md
+++ b/docs/docs/docs/guides/usage-with-react-navigation.md
@@ -53,7 +53,7 @@ Whether to show labels in tabs. Defaults to true.
 
 #### `rippleColor`
 
-change ripple color on tab press. (Android Only)
+Changes ripple color on tab press. (Android Only)
 
 #### `disablePageAnimations`
 

--- a/docs/docs/docs/guides/usage-with-react-navigation.md
+++ b/docs/docs/docs/guides/usage-with-react-navigation.md
@@ -5,7 +5,7 @@ To use this navigator, ensure that you have [`@react-navigation/native` and its 
 :::
 
 ```tsx
-import {createNativeBottomTabNavigator} from 'react-native-bottom-tabs/react-navigation';
+import { createNativeBottomTabNavigator } from 'react-native-bottom-tabs/react-navigation';
 
 const Tabs = createNativeBottomTabNavigator();
 
@@ -15,15 +15,15 @@ function NativeBottomTabs() {
       <Tabs.Screen
         name="index"
         options={{
-          title: "Home",
-          tabBarIcon: () => ({ sfSymbol: "house" }),
+          title: 'Home',
+          tabBarIcon: () => ({ sfSymbol: 'house' }),
         }}
       />
       <Tabs.Screen
         name="explore"
         options={{
-          title: "Explore",
-          tabBarIcon: () => ({ sfSymbol: "person" }),
+          title: 'Explore',
+          tabBarIcon: () => ({ sfSymbol: 'person' }),
         }}
       />
     </Tabs.Navigator>
@@ -51,6 +51,10 @@ Default options to use for the screens in the navigator.
 
 Whether to show labels in tabs. Defaults to true.
 
+#### `rippleColor`
+
+change ripple color on tab press. (Android Only)
+
 #### `disablePageAnimations`
 
 Whether to disable page animations between tabs. (iOS only)
@@ -60,21 +64,23 @@ Whether to disable page animations between tabs. (iOS only)
 Describes the appearance attributes for the tabBar to use when an observable scroll view is scrolled to the bottom. (iOS only)
 
 Available options:
+
 - `default` - uses default background and shadow values.
 - `transparent` - uses transparent background and no shadow.
 - `opaque` - uses set of opaque colors that are appropriate for the current theme
 
 Note: It's recommended to use `transparent` or `opaque` without lazy loading as the tab bar background flashes when a view is rendered lazily.
+
 #### `sidebarAdaptable`
 
 A tab bar style that adapts to each platform. (Apple platforms only)
 
 Tab views using the sidebar adaptable style have an appearance
+
 - iPadOS displays a top tab bar that can adapt into a sidebar.
 - iOS displays a bottom tab bar.
 - macOS and tvOS always show a sidebar.
 - visionOS shows an ornament and also shows a sidebar for secondary tabs within a `TabSection`.
-
 
 ### Options
 
@@ -104,7 +110,6 @@ Note: SF Symbols are only supported on Apple platforms.
     tabBarIcon: () => ({ sfSymbol: 'person' }),
   }}
 />
-
 ```
 
 #### `tabBarBadge`

--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -57,7 +57,7 @@ Whether to show labels in tabs. Defaults to true.
 
 Changes ripple color on tab press. (Android Only)
 
-#### `disablePageAnimations`
+#### `disablePageAnimations` <Badge text="iOS" type="info" />
 
 Whether to disable page animations between tabs.
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -27,6 +27,10 @@ const FourTabsIgnoreSafeArea = () => {
   return <FourTabs ignoresTopSafeArea />;
 };
 
+const FourTabsRippleColor = () => {
+  return <FourTabs rippleColor={'#00ff00'} />;
+};
+
 const FourTabsNoAnimations = () => {
   return <FourTabs disablePageAnimations />;
 };
@@ -44,6 +48,10 @@ const examples = [
     component: FourTabsIgnoreSafeArea,
     name: 'Four Tabs - No header',
     screenOptions: { headerShown: false },
+  },
+  {
+    component: FourTabsRippleColor,
+    name: 'Four Tabs with ripple Color',
   },
   { component: FourTabsNoAnimations, name: 'Four Tabs - no animations' },
   {

--- a/example/src/Examples/FourTabs.tsx
+++ b/example/src/Examples/FourTabs.tsx
@@ -4,17 +4,20 @@ import { Article } from '../Screens/Article';
 import { Albums } from '../Screens/Albums';
 import { Contacts } from '../Screens/Contacts';
 import { Chat } from '../Screens/Chat';
+import { ColorValue } from 'react-native';
 
 interface Props {
   ignoresTopSafeArea?: boolean;
   disablePageAnimations?: boolean;
   scrollEdgeAppearance?: 'default' | 'opaque' | 'transparent';
+  rippleColor?: ColorValue;
 }
 
 export default function FourTabs({
   ignoresTopSafeArea = false,
   disablePageAnimations = false,
   scrollEdgeAppearance = 'default',
+  rippleColor,
 }: Props) {
   const [index, setIndex] = useState(0);
   const [routes] = useState([
@@ -59,6 +62,7 @@ export default function FourTabs({
       navigationState={{ index, routes }}
       onIndexChange={setIndex}
       renderScene={renderScene}
+      rippleColor={rippleColor}
     />
   );
 }

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -1,5 +1,12 @@
 import type { TabViewItems } from './TabViewNativeComponent';
-import { Image, Platform, StyleSheet, View } from 'react-native';
+import {
+  ColorValue,
+  Image,
+  Platform,
+  StyleSheet,
+  View,
+  processColor,
+} from 'react-native';
 
 //@ts-ignore
 import type { ImageSource } from 'react-native/Libraries/Image/ImageSource';
@@ -77,6 +84,8 @@ interface Props<Route extends BaseRoute> {
     route: Route;
     focused: boolean;
   }) => ImageSource | undefined;
+
+  rippleColor?: ColorValue;
 }
 
 const ANDROID_MAX_TABS = 6;
@@ -180,6 +189,7 @@ const TabView = <Route extends BaseRoute>({
         jumpTo(key);
       }}
       {...props}
+      rippleColor={processColor(props.rippleColor)}
     >
       {trimmedRoutes.map((route) => {
         if (getLazy({ route }) !== false && !loaded.includes(route.key)) {

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -1,5 +1,5 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps } from 'react-native';
+import type { ViewProps, ProcessedColorValue } from 'react-native';
 import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 //@ts-ignore
 import type { ImageSource } from 'react-native/Libraries/Image/ImageSource';
@@ -23,6 +23,7 @@ export interface TabViewProps extends ViewProps {
   labeled?: boolean;
   sidebarAdaptable?: boolean;
   scrollEdgeAppearance?: string;
+  rippleColor?: ProcessedColorValue | null;
 }
 
 export default codegenNativeComponent<TabViewProps>('RCTTabView');


### PR DESCRIPTION
Part of this: https://github.com/okwasniewski/react-native-bottom-tabs/issues/11

**Summary**: This PR updates the ripple color of tab bar click for Android implementations.

**Testing**:

Verified Ripple color changes on Android.
Added FourTabsRippleColor for visual changes.

Adding Video for reference

https://github.com/user-attachments/assets/7cb8e2eb-b56c-4546-824a-315b11bd80ca

