### PR TITLE
docs: Remove stability notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@
 
 </div>
 
-> [!CAUTION]
-> This library is in early development and not ready for production use.
-
 https://github.com/user-attachments/assets/fbdd9ce2-f4b9-4d0c-bd91-2e62bb422d69
 
 ## Documentation


### PR DESCRIPTION
Remove _early development_ badge, this means that the library API is stable but **it doesn't mean that it's bug free**(!)

