### PR TITLE
fix: codegen didn't run warning on android

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   presets: [
+    'module:@react-native/babel-preset',
     ['module:react-native-builder-bob/babel-preset', { modules: 'commonjs' }],
   ],
 };

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.2",
     "@evilmartians/lefthook": "^1.5.0",
+    "@react-native/babel-preset": "0.75.3",
     "@react-native/eslint-config": "^0.73.1",
     "@react-navigation/native": "^6.1.18",
     "@types/color": "^3.0.6",
@@ -180,13 +181,15 @@
       [
         "commonjs",
         {
-          "esm": true
+          "esm": true,
+          "configFile": true
         }
       ],
       [
         "module",
         {
-          "esm": true
+          "esm": true,
+          "configFile": true
         }
       ],
       [

--- a/yarn.lock
+++ b/yarn.lock
@@ -13585,6 +13585,7 @@ __metadata:
   dependencies:
     "@commitlint/config-conventional": ^17.0.2
     "@evilmartians/lefthook": ^1.5.0
+    "@react-native/babel-preset": 0.75.3
     "@react-native/eslint-config": ^0.73.1
     "@react-navigation/native": ^6.1.18
     "@types/color": ^3.0.6


### PR DESCRIPTION
Fixes #87 
This fixes a warning that we got when running the library on Android:
`(NOBRIDGE) WARN  Codegen didn't run for RNCTabView. This will be an error in the future. Make sure you are using @react-native/babel-preset when building your JavaScript code.`

Looks like React Native now requires the user to transpile their code using the react native babel preset. This PR adds the babel preset to babel config and tells builder bob to use the preset.

This is a temporary fix and we will add this plugin directly to bob in the future.

## How to test this?

1. Use yalc or package the library using `yarn pack`
2. Create a new React Native app and consume the package
3. Make sure there is no `NOBRIDGE) WARN  Codegen didn't run for RNCTabView. This will be an error in the future. Make sure you are using @react-native/babel-preset when building your JavaScript code.` warning.