### PR TITLE
feat: native support for haptic feedback

### DIFF
--- a/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -5,8 +5,10 @@ import android.content.res.ColorStateList
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.util.TypedValue
 import android.view.Choreographer
+import android.view.HapticFeedbackConstants
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
@@ -34,6 +36,7 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
   private var inactiveTintColor: Int? = null
   private val checkedStateSet = intArrayOf(android.R.attr.state_checked)
   private val uncheckedStateSet = intArrayOf(-android.R.attr.state_checked)
+  private var hapticFeedbackEnabled = true
 
   private val layoutCallback = Choreographer.FrameCallback {
     isLayoutEnqueued = false
@@ -59,6 +62,7 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
         putString("key", longPressedItem.key)
       }
       onTabLongPressedListener?.invoke(event)
+      emitHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
     }
   }
 
@@ -88,6 +92,7 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
         putString("key", selectedItem.key)
       }
       onTabSelectedListener?.invoke(event)
+      emitHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK)
     }
   }
 
@@ -198,6 +203,16 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
 
   fun setActiveIndicatorColor(color: ColorStateList) {
     itemActiveIndicatorColor = color
+  }
+
+  fun setHapticFeedback(enabled: Boolean) {
+    hapticFeedbackEnabled = enabled
+  }
+
+  fun emitHapticFeedback(feedbackConstants: Int) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && hapticFeedbackEnabled) {
+      this.performHapticFeedback(feedbackConstants)
+    }
   }
 
   private fun updateTintColors(item: MenuItem? = null) {

--- a/android/src/main/java/com/rcttabview/RCTTabViewImpl.kt
+++ b/android/src/main/java/com/rcttabview/RCTTabViewImpl.kt
@@ -77,6 +77,10 @@ class RCTTabViewImpl {
     view.setInactiveTintColor(color)
   }
 
+  fun setHapticFeedbackEnabled(view: ReactBottomNavigationView, enabled: Boolean) {
+   view.setHapticFeedback(enabled)
+  }
+
   fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
     return MapBuilder.of(
       PageSelectedEvent.EVENT_NAME,

--- a/android/src/newarch/RCTTabViewManager.kt
+++ b/android/src/newarch/RCTTabViewManager.kt
@@ -98,6 +98,11 @@ class RCTTabViewManager(context: ReactApplicationContext) :
     return delegate
   }
 
+  override fun setHapticFeedbackEnabled(view: ReactBottomNavigationView?, value: Boolean) {
+    if (view != null)
+      tabViewImpl.setHapticFeedbackEnabled(view, value)
+  }
+
   public override fun measure(
     context: Context?,
     localData: ReadableMap?,

--- a/android/src/oldarch/RCTTabViewManager.kt
+++ b/android/src/oldarch/RCTTabViewManager.kt
@@ -109,6 +109,11 @@ class RCTTabViewManager(context: ReactApplicationContext) : SimpleViewManager<Re
   fun setDisablePageAnimations(view: ReactBottomNavigationView, flag: Boolean) {
   }
 
+  @ReactProp(name = "hapticFeedbackEnabled")
+  fun setHapticFeedbackEnabled(view: ReactBottomNavigationView, value: Boolean) {
+      tabViewImpl.setHapticFeedbackEnabled(view, value)
+  }
+
   class TabViewShadowNode() : LayoutShadowNode(),
     YogaMeasureFunction {
     private var mWidth = 0

--- a/docs/docs/docs/getting-started/how-is-it-different.mdx
+++ b/docs/docs/docs/getting-started/how-is-it-different.mdx
@@ -38,6 +38,10 @@ TabView can turn in to a side bar on tvOS, iPadOS and macOS. This is controlled 
 
 SwiftUI's TabView offer built-in smooth animations between tabs.
 
+### Out of the box support for Haptic Feedback
+
+Using one prop you can add haptic feedback support to your tab bar on both Android and iOS. This can significantly enhance users experience.
+
 ## When to use JS Bottom Tabs
 
 Using native components enforce certain constraints that we need to adapt to.

--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -118,6 +118,10 @@ Tab views using the sidebar adaptable style have an appearance
 - macOS and tvOS always show a sidebar.
 - visionOS shows an ornament and also shows a sidebar for secondary tabs within a `TabSection`.
 
+#### `hapticFeedbackEnabled`
+
+Whether to enable haptic feedback on tab press. Defaults to true.
+
 ### Options
 
 The following options can be used to configure the screens in the navigator. These can be specified under `screenOptions` prop of `Tab.navigator` or `options` prop of `Tab.Screen`.

--- a/example/src/Examples/NativeBottomTabs.tsx
+++ b/example/src/Examples/NativeBottomTabs.tsx
@@ -11,6 +11,7 @@ const Tab = createNativeBottomTabNavigator();
 function NativeBottomTabs() {
   return (
     <Tab.Navigator
+      hapticFeedbackEnabled={false}
       tabBarInactiveTintColor="#C57B57"
       tabBarActiveTintColor="#F7DBA7"
       barTintColor="#1E2D2F"

--- a/ios/Fabric/RCTTabViewComponentView.mm
+++ b/ios/Fabric/RCTTabViewComponentView.mm
@@ -140,7 +140,11 @@ using namespace facebook::react;
   }
 
   if (oldViewProps.inactiveTintColor != newViewProps.inactiveTintColor) {
-    _tabViewProvider.inactiveTintColor =  RCTUIColorFromSharedColor(newViewProps.inactiveTintColor);
+    _tabViewProvider.inactiveTintColor = RCTUIColorFromSharedColor(newViewProps.inactiveTintColor);
+  }
+  
+  if (oldViewProps.hapticFeedbackEnabled != newViewProps.hapticFeedbackEnabled) {
+    _tabViewProvider.hapticFeedbackEnabled = newViewProps.hapticFeedbackEnabled;
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/RCTTabViewViewManager.mm
+++ b/ios/RCTTabViewViewManager.mm
@@ -42,6 +42,7 @@ RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(activeTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(inactiveTintColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(hapticFeedbackEnabled, BOOL)
 
 //  MARK: TabViewProviderDelegate
 

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -19,6 +19,7 @@ class TabViewProps: ObservableObject {
   @Published var barTintColor: UIColor?
   @Published var activeTintColor: UIColor?
   @Published var inactiveTintColor: UIColor?
+  @Published var hapticFeedbackEnabled: Bool = true
   
   var selectedActiveTintColor: UIColor? {
     if let selectedPage = selectedPage,
@@ -80,6 +81,7 @@ struct TabViewImpl: View {
     .onTabItemLongPress({ index in
       if let key = props.items[safe: index]?.key {
         onLongPress(key)
+        emitHapticFeedback(longPress: true)
       }
     })
     .tintColor(props.selectedActiveTintColor)
@@ -94,7 +96,22 @@ struct TabViewImpl: View {
       }
       
       onSelect(newValue)
+      emitHapticFeedback()
     }
+  }
+  
+  func emitHapticFeedback(longPress: Bool = false) {
+#if os(iOS)
+    if !props.hapticFeedbackEnabled {
+      return
+    }
+    
+    if longPress {
+      UINotificationFeedbackGenerator().notificationOccurred(.success)
+    } else {
+      UISelectionFeedbackGenerator().selectionChanged()
+    }
+#endif
   }
 }
 

--- a/ios/TabViewProvider.swift
+++ b/ios/TabViewProvider.swift
@@ -86,6 +86,12 @@ import React
     }
   }
   
+  @objc public var hapticFeedbackEnabled: Bool = true {
+    didSet {
+      props.hapticFeedbackEnabled = hapticFeedbackEnabled
+    }
+  }
+  
   @objc public var scrollEdgeAppearance: NSString? {
     didSet {
       props.scrollEdgeAppearance = scrollEdgeAppearance as? String

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -38,11 +38,14 @@ interface Props<Route extends BaseRoute> {
    * Whether to ignore the top safe area. (iOS only)
    */
   ignoresTopSafeArea?: boolean;
-
   /**
    * Whether to disable page animations between tabs. (iOS only)
    */
   disablePageAnimations?: boolean;
+  /**
+   * Whether to enable haptic feedback. Defaults to `true`.
+   */
+  hapticFeedbackEnabled?: boolean;
   /**
    * Describes the appearance attributes for the tabBar to use when an observable scroll view is scrolled to the bottom. (iOS only)
    */
@@ -135,6 +138,7 @@ const TabView = <Route extends BaseRoute>({
   getActiveTintColor = ({ route }: { route: Route }) => route.activeTintColor,
   tabBarActiveTintColor: activeTintColor,
   tabBarInactiveTintColor: inactiveTintColor,
+  hapticFeedbackEnabled = true,
   rippleColor,
   ...props
 }: Props<Route>) => {
@@ -216,6 +220,7 @@ const TabView = <Route extends BaseRoute>({
 
   return (
     <TabViewAdapter
+      {...props}
       style={styles.fullWidth}
       items={items}
       icons={resolvedIconAssets}
@@ -227,7 +232,7 @@ const TabView = <Route extends BaseRoute>({
       onPageSelected={({ nativeEvent: { key } }) => {
         jumpTo(key);
       }}
-      {...props}
+      hapticFeedbackEnabled={hapticFeedbackEnabled}
       activeTintColor={activeTintColor}
       inactiveTintColor={inactiveTintColor}
       barTintColor={barTintColor}

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -33,6 +33,7 @@ export interface TabViewProps extends ViewProps {
   ignoresTopSafeArea?: boolean;
   disablePageAnimations?: boolean;
   activeIndicatorColor?: ColorValue;
+  hapticFeedbackEnabled?: boolean;
 }
 
 export default codegenNativeComponent<TabViewProps>('RNCTabView', {


### PR DESCRIPTION
This PR adds native support for haptic feedback!

It uses performHapticFeedback on Android and `UINotificationFeedbackGenerator` on iOS

It's enabled by default and can be disabled by passing `hapticFeedbackEnabled={false}` to the navigator