### PR TITLE
docs: fix rspress compiler error

### DIFF
--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -184,7 +184,7 @@ This event is fired when the user presses the tab button for the current screen 
 
 To prevent the default behavior, you can call `event.preventDefault`:
 
-```tsx`
+```tsx
 React.useEffect(() => {
   const unsubscribe = navigation.addListener('tabPress', (e) => {
     // Prevent default behavior


### PR DESCRIPTION
[usage-with-react-navigation](https://okwasniewski.github.io/react-native-bottom-tabs/docs/guides/usage-with-react-navigation.html) unable to view.

Reported the following error:
`react-native-bottom-tabs/docs/docs/docs/guides/usage-with-react-navigation.mdx`
> Error: "191:24: Unexpected end of file in expression, expected a corresponding closing brace for `{`"