### PR TITLE
fix: layouting on Android move to zIndex

### DIFF
--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -253,16 +253,21 @@ const TabView = <Route extends BaseRoute>({
           );
         }
 
+        const focused = route.key === focusedKey;
+        const zIndex = focused ? 1 : 0;
+
         return (
           <View
             key={route.key}
             collapsable={false}
-            style={[
-              styles.fullWidth,
-              Platform.OS === 'android' && {
-                display: route.key === focusedKey ? 'flex' : 'none',
-              },
-            ]}
+            pointerEvents={focused ? 'auto' : 'none'}
+            accessibilityElementsHidden={!focused}
+            importantForAccessibility={focused ? 'auto' : 'no-hide-descendants'}
+            style={
+              Platform.OS === 'android'
+                ? [StyleSheet.absoluteFill, { zIndex }]
+                : styles.fullWidth
+            }
           >
             {renderScene({
               route,

--- a/src/TabViewAdapter.android.tsx
+++ b/src/TabViewAdapter.android.tsx
@@ -2,11 +2,11 @@ import NativeTabView from './TabViewNativeComponent';
 import type { TabViewProps } from './TabViewNativeComponent';
 import { StyleSheet, View } from 'react-native';
 
-const TabViewAdapter = ({ children, ...props }: TabViewProps) => {
+const TabViewAdapter = ({ children, style: _, ...props }: TabViewProps) => {
   return (
     <>
       <View style={styles.content}>{children}</View>
-      <NativeTabView {...props} style={styles.tabBar} />
+      <NativeTabView {...props} />
     </>
   );
 };
@@ -24,7 +24,6 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
   },
-  tabBar: {},
 });
 
 export default TabViewAdapter;


### PR DESCRIPTION
This PR fixes #123 

We switch from using display: none/flex as the future to hide views on Android instead of using zIndex as in React Native Paper's bottom tabs component. 