### PR TITLE
fix: change ignoresTopSafeArea defalt to true in order to match JS Tabs

### DIFF
--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -35,7 +35,7 @@ function SettingsScreen() {
 export default function App() {
   return (
     <NavigationContainer>
-      <Tab.Navigator ignoresTopSafeArea>
+      <Tab.Navigator>
         <Tab.Screen
           name="Home"
           component={HomeScreen}
@@ -70,7 +70,7 @@ The name of the route to render on first load of the navigator.
 
 #### `ignoresTopSafeArea` <Badge text="iOS" type="info" />
 
-Whether to ignore the top safe area.
+Whether to ignore the top safe area. Defaults to `true`.
 
 #### `screenOptions`
 

--- a/example/src/Examples/NativeBottomTabsEmbeddedStacks.tsx
+++ b/example/src/Examples/NativeBottomTabsEmbeddedStacks.tsx
@@ -67,7 +67,7 @@ function ChatStackScreen() {
 
 function NativeBottomTabsEmbeddedStacks() {
   return (
-    <Tab.Navigator ignoresTopSafeArea>
+    <Tab.Navigator>
       <Tab.Screen
         name="Article"
         component={ArticleStackScreen}

--- a/ios/TabViewProvider.swift
+++ b/ios/TabViewProvider.swift
@@ -41,98 +41,98 @@ import React
   private var coalescingKey: UInt16 = 0
   private var imageLoader: RCTImageLoaderProtocol?
   private var iconSize = CGSize(width: 27, height: 27)
-  
+
   @objc var onPageSelected: RCTDirectEventBlock?
-  
+
   @objc var onTabLongPress: RCTDirectEventBlock?
-  
+
   @objc public var icons: NSArray? {
     didSet {
       loadIcons(icons)
     }
   }
-  
+
   @objc public var children: [UIView] = [] {
     didSet {
       props.children = children
     }
   }
-  
+
   @objc public var sidebarAdaptable: Bool = false {
     didSet {
       props.sidebarAdaptable = sidebarAdaptable
     }
   }
-  
-  
+
+
   @objc public var disablePageAnimations: Bool = false {
     didSet {
       props.disablePageAnimations = disablePageAnimations
     }
   }
-  
+
   @objc public var labeled: Bool = true {
     didSet {
       props.labeled = labeled
     }
   }
-  
-  @objc public var ignoresTopSafeArea: Bool = false {
+
+  @objc public var ignoresTopSafeArea: Bool = true {
     didSet {
       props.ignoresTopSafeArea = ignoresTopSafeArea
     }
   }
-  
+
   @objc public var selectedPage: NSString? {
     didSet {
       props.selectedPage = selectedPage as? String
     }
   }
-  
+
   @objc public var hapticFeedbackEnabled: Bool = true {
     didSet {
       props.hapticFeedbackEnabled = hapticFeedbackEnabled
     }
   }
-  
+
   @objc public var scrollEdgeAppearance: NSString? {
     didSet {
       props.scrollEdgeAppearance = scrollEdgeAppearance as? String
     }
   }
-  
+
   @objc public var translucent: Bool = true {
     didSet {
       props.translucent = translucent
     }
   }
-  
+
   @objc var items: NSArray? {
     didSet {
       props.items = parseTabData(from: items)
     }
   }
-  
+
   @objc public var barTintColor: UIColor? {
     didSet {
       props.barTintColor = barTintColor
     }
   }
-  
+
   @objc public var activeTintColor: UIColor? {
     didSet {
       props.activeTintColor = activeTintColor
     }
   }
-  
+
   @objc public var inactiveTintColor: UIColor? {
     didSet {
       props.inactiveTintColor = inactiveTintColor
     }
   }
-  
+
   // New arch specific properties
-  
+
   @objc public var itemsData: [TabInfo] = [] {
     didSet {
       props.items = itemsData
@@ -144,21 +144,21 @@ import React
     self.delegate = delegate
     self.imageLoader = imageLoader
   }
-  
+
   public override func didUpdateReactSubviews() {
     props.children = reactSubviews()
   }
-  
+
   public override func layoutSubviews() {
     super.layoutSubviews()
     setupView()
   }
-  
+
   private func setupView() {
     if self.hostingController != nil {
       return
     }
-    
+
     self.hostingController = UIHostingController(rootView: TabViewImpl(props: props) { key in
       self.delegate?.onPageSelected(key: key, reactTag: self.reactTag)
     } onLongPress: { key in
@@ -172,7 +172,7 @@ import React
       hostingController.didMove(toParent: parentViewController)
     }
   }
-  
+
   private func loadIcons(_ icons: NSArray?) {
     // TODO: Diff the arrays and update only changed items.
     // Now if the user passes `unfocusedIcon` we update every item.
@@ -200,11 +200,11 @@ import React
       }
     }
   }
-  
+
   private func parseTabData(from array: NSArray?) -> [TabInfo] {
     guard let array else { return [] }
     var items: [TabInfo] = []
-    
+
     for value in array {
       if let itemDict = value as? [String: Any] {
         items.append(
@@ -219,7 +219,7 @@ import React
         )
       }
     }
-    
+
     return items
   }
 }

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -39,7 +39,7 @@ interface Props<Route extends BaseRoute> {
    */
   ignoresTopSafeArea?: boolean;
   /**
-   * Whether to disable page animations between tabs. (iOS only)
+   * Whether to disable page animations between tabs. (iOS only) Defaults to `true`.
    */
   disablePageAnimations?: boolean;
   /**

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -1,6 +1,9 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ColorValue, ProcessedColorValue, ViewProps } from 'react-native';
-import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
+import type {
+  DirectEventHandler,
+  WithDefault,
+} from 'react-native/Libraries/Types/CodegenTypes';
 //@ts-ignore
 import type { ImageSource } from 'react-native/Libraries/Image/ImageSource';
 
@@ -31,7 +34,7 @@ export interface TabViewProps extends ViewProps {
   rippleColor?: ColorValue;
   activeTintColor?: ColorValue;
   inactiveTintColor?: ColorValue;
-  ignoresTopSafeArea?: boolean;
+  ignoresTopSafeArea?: WithDefault<boolean, true>;
   disablePageAnimations?: boolean;
   activeIndicatorColor?: ColorValue;
   hapticFeedbackEnabled?: boolean;


### PR DESCRIPTION
This PR changes `ignoresTopSafeArea` prop to true by default in order to match behavior from JS tabs. 

In 95% of cases users needed to add ignoresTopSafeArea anyways. 