### PR TITLE
fix: hide routes with opacity 0 for Android

### DIFF
--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -271,6 +271,7 @@ const TabView = <Route extends BaseRoute>({
         }
 
         const focused = route.key === focusedKey;
+        const opacity = focused ? 1 : 0;
         const zIndex = focused ? 0 : -1;
 
         return (
@@ -282,7 +283,7 @@ const TabView = <Route extends BaseRoute>({
             importantForAccessibility={focused ? 'auto' : 'no-hide-descendants'}
             style={
               Platform.OS === 'android'
-                ? [StyleSheet.absoluteFill, { zIndex }]
+                ? [StyleSheet.absoluteFill, { zIndex, opacity }]
                 : styles.fullWidth
             }
           >


### PR DESCRIPTION
This PR fixes an issue where if you have transparent background of the route it can be visible while being on a different route. 

This was also an issue on AndroidTV, cc: @douglowder 