### PR TITLE
Autofix: White screen issue with sidebarAdaptable

### DIFF
--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -219,10 +219,12 @@ extension View {
   @ViewBuilder
   func getSidebarAdaptable(enabled: Bool) -> some View {
     if #available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, *) {
-      if (enabled) {
-#if compiler(>=6.0)
-        self.tabViewStyle(.sidebarAdaptable)
-#endif
+      if enabled {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+          self.tabViewStyle(.sidebarAdaptable)
+        } else {
+          self
+        }
       } else {
         self
       }
@@ -230,6 +232,7 @@ extension View {
       self
     }
   }
+  func getSidebarAdaptable(enabled: Bool) -> some View {
 
   @ViewBuilder
   func tabBadge(_ data: String?) -> some View {


### PR DESCRIPTION
Modified the TabViewImpl struct to properly handle the sidebarAdaptable property on iOS 18 and above. This should fix the whitescreen issue on iPhone 16 Pro with iOS 18.2 public beta. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    