### PR TITLE
fix: appearance handling on iOS

### DIFF
--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -37,3 +37,16 @@ extension UIImage {
     return resizedImage
   }
 }
+
+extension View {
+  @ViewBuilder
+  func introspectTabView(closure: @escaping (UITabBarController) -> Void) -> some View {
+    self
+      .introspect(
+        .tabView,
+        on: .iOS(.v14, .v15, .v16, .v17, .v18),
+        .tvOS(.v14,.v15, .v16, .v17, .v18),
+        customize: closure
+      )
+  }
+}

--- a/ios/TabItemEventModifier.swift
+++ b/ios/TabItemEventModifier.swift
@@ -18,12 +18,9 @@ struct TabItemEventModifier: ViewModifier {
   
   func body(content: Content) -> some View {
     content
-      .introspect(.tabView, on: .iOS(.v14, .v15, .v16, .v17, .v18)) { tabController in
+      .introspectTabView(closure: { tabController in
         handle(tabController: tabController)
-      }
-      .introspect(.tabView, on: .tvOS(.v14, .v15, .v16, .v17, .v18)) { tabController in
-        handle(tabController: tabController)
-      }
+      })
   }
   
   func handle(tabController: UITabBarController) {


### PR DESCRIPTION
This PR should fix: #124 


![CleanShot 2024-11-09 at 10 33 02@2x](https://github.com/user-attachments/assets/4b5f9ccc-c52e-45bf-b500-42213ef68270)
![CleanShot 2024-11-09 at 10 32 44@2x](https://github.com/user-attachments/assets/71a84b06-1301-4d64-9f35-37bbb193dab7)

It's also a partial fix for #128, it appears that everything works properly with `scrollEdgeApperance="transparent"`. 

If we override `tabBar.scrollEdgeAppearance` then it's breaking. It is a bug in SwiftUI's tab view component which we can do nothing about 😢 (other than open a issue for apple)