### PR TITLE
fix(iOS): various fixes for Apple TV

### DIFF
--- a/ios/PageSelectedEvent.swift
+++ b/ios/PageSelectedEvent.swift
@@ -27,7 +27,7 @@ import React
   @objc public func arguments() -> [Any] {
     return [
       viewTag,
-      RCTNormalizeInputEventName(eventName),
+      RCTNormalizeInputEventName(eventName) ?? eventName,
       [
         "key": key
       ]

--- a/ios/TabLongPressedEvent.swift
+++ b/ios/TabLongPressedEvent.swift
@@ -31,7 +31,7 @@ protocol RCTEvent {}
   @objc public func arguments() -> [Any] {
     return [
       viewTag,
-      RCTNormalizeInputEventName(eventName),
+      RCTNormalizeInputEventName(eventName) ?? eventName,
       [
         "key": key
       ]

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -63,6 +63,7 @@ struct TabViewImpl: View {
         renderTabItem(at: index)
       }
     }
+    #if !os(tvOS)
     .onTabItemEvent({ index, isLongPress in
       guard let key = props.items.filter({
         !$0.hidden || $0.key == props.selectedPage
@@ -76,6 +77,7 @@ struct TabViewImpl: View {
         emitHapticFeedback()
       }
     })
+    #endif
     .introspectTabView(closure: { tabController in
       tabBar = tabController.tabBar
     })
@@ -92,6 +94,9 @@ struct TabViewImpl: View {
           UIView.setAnimationsEnabled(true)
         }
       }
+      #if os(tvOS)
+      onSelect(newValue)
+      #endif
     }
   }
 
@@ -278,7 +283,7 @@ extension View {
   func tintColor(_ color: UIColor?) -> some View {
     if let color {
       let color = Color(color)
-      if #available(iOS 16.0, *) {
+      if #available(iOS 16.0, tvOS 16.0, *) {
         self.tint(color)
       } else {
         self.accentColor(color)
@@ -292,7 +297,7 @@ extension View {
   // By default they are always filled.
   @ViewBuilder
   func noneSymbolVariant() -> some View {
-    if #available(iOS 15.0, *) {
+    if #available(iOS 15.0, tvOS 15.0, *) {
       self
         .environment(\.symbolVariants, .none)
     } else {

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -63,7 +63,7 @@ struct TabViewImpl: View {
         renderTabItem(at: index)
       }
     }
-    #if !os(tvOS)
+#if !os(tvOS)
     .onTabItemEvent({ index, isLongPress in
       guard let key = props.items.filter({
         !$0.hidden || $0.key == props.selectedPage
@@ -77,7 +77,7 @@ struct TabViewImpl: View {
         emitHapticFeedback()
       }
     })
-    #endif
+#endif
     .introspectTabView(closure: { tabController in
       tabBar = tabController.tabBar
     })
@@ -94,9 +94,9 @@ struct TabViewImpl: View {
           UIView.setAnimationsEnabled(true)
         }
       }
-      #if os(tvOS)
+#if os(tvOS)
       onSelect(newValue)
-      #endif
+#endif
     }
   }
 


### PR DESCRIPTION
The changes in #116 introduced noticeable rerendering in tvOS when using the arrow key or swipe gesture on the remote to change tabs.

The issue is that on tvOS, tabs are not selected by a press event, so the `onTabItemEvent()` handler is unnecessarily redrawing the tab bar.

This PR fixes that issue, and adds tvOS version checks to the existing iOS version checks.

Also fixed warnings in `PageSelectedEvent.swift`.

