### PR TITLE
feat: add custom fonts support

### DIFF
--- a/android/src/newarch/RCTTabViewManager.kt
+++ b/android/src/newarch/RCTTabViewManager.kt
@@ -127,6 +127,18 @@ class RCTTabViewManager(context: ReactApplicationContext) :
     )
   }
 
+  override fun setFontFamily(view: ReactBottomNavigationView?, value: String?) {
+    view?.setFontFamily(value)
+  }
+
+  override fun setFontWeight(view: ReactBottomNavigationView?, value: String?) {
+    view?.setFontWeight(value)
+  }
+
+  override fun setFontSize(view: ReactBottomNavigationView?, value: Int) {
+    view?.setFontSize(value)
+  }
+
   // iOS Methods
 
   override fun setTranslucent(view: ReactBottomNavigationView?, value: Boolean) {
@@ -143,4 +155,6 @@ class RCTTabViewManager(context: ReactApplicationContext) :
 
   override fun setScrollEdgeAppearance(view: ReactBottomNavigationView?, value: String?) {
   }
+
+
 }

--- a/android/src/oldarch/RCTTabViewManager.kt
+++ b/android/src/oldarch/RCTTabViewManager.kt
@@ -114,6 +114,21 @@ class RCTTabViewManager(context: ReactApplicationContext) : SimpleViewManager<Re
       tabViewImpl.setHapticFeedbackEnabled(view, value)
   }
 
+  @ReactProp(name = "fontFamily")
+  fun setFontFamily(view: ReactBottomNavigationView?, value: String?) {
+    view?.setFontFamily(value)
+  }
+
+  @ReactProp(name = "fontWeight")
+  fun setFontWeight(view: ReactBottomNavigationView?, value: String?) {
+    view?.setFontWeight(value)
+  }
+
+  @ReactProp(name = "fontSize")
+  fun setFontSize(view: ReactBottomNavigationView?, value: Int) {
+    view?.setFontSize(value)
+  }
+
   class TabViewShadowNode() : LayoutShadowNode(),
     YogaMeasureFunction {
     private var mWidth = 0

--- a/docs/docs/docs/guides/standalone-usage.md
+++ b/docs/docs/docs/guides/standalone-usage.md
@@ -133,6 +133,15 @@ Whether to enable haptic feedback on tab press.
 - Type: `boolean`
 - Default: `true`
 
+
+#### `tabLabelStyle`
+
+Object containing styles for the tab label.
+Supported properties:
+- `fontFamily`
+- `fontSize`
+- `fontWeight`
+
 #### `scrollEdgeAppearance` <Badge text="iOS" type="info" />
 
 Appearance attributes for the tab bar when a scroll view is at the bottom.

--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -149,6 +149,16 @@ Tab views using the sidebar adaptable style have an appearance
 
 Whether to enable haptic feedback on tab press. Defaults to true.
 
+#### `tabLabelStyle`
+
+Object containing styles for the tab label.
+
+Supported properties:
+- `fontFamily`
+- `fontSize`
+- `fontWeight`
+
+
 ### Options
 
 The following options can be used to configure the screens in the navigator. These can be specified under `screenOptions` prop of `Tab.navigator` or `options` prop of `Tab.Screen`.

--- a/example/src/Examples/NativeBottomTabs.tsx
+++ b/example/src/Examples/NativeBottomTabs.tsx
@@ -18,6 +18,8 @@ function NativeBottomTabs() {
       tabBarActiveTintColor="#F7DBA7"
       barTintColor="#1E2D2F"
       rippleColor="#F7DBA7"
+      fontFamily="Avenir"
+      fontSize={15}
       activeIndicatorColor="#041F1E"
       screenListeners={{
         tabLongPress: (data) => {

--- a/example/src/Examples/NativeBottomTabs.tsx
+++ b/example/src/Examples/NativeBottomTabs.tsx
@@ -18,8 +18,10 @@ function NativeBottomTabs() {
       tabBarActiveTintColor="#F7DBA7"
       barTintColor="#1E2D2F"
       rippleColor="#F7DBA7"
-      fontFamily="Avenir"
-      fontSize={15}
+      tabLabelStyle={{
+        fontFamily: 'Avenir',
+        fontSize: 15,
+      }}
       activeIndicatorColor="#041F1E"
       screenListeners={{
         tabLongPress: (data) => {

--- a/ios/Fabric/RCTTabViewComponentView.mm
+++ b/ios/Fabric/RCTTabViewComponentView.mm
@@ -146,6 +146,18 @@ using namespace facebook::react;
   if (oldViewProps.hapticFeedbackEnabled != newViewProps.hapticFeedbackEnabled) {
     _tabViewProvider.hapticFeedbackEnabled = newViewProps.hapticFeedbackEnabled;
   }
+  
+  if (oldViewProps.fontSize != newViewProps.fontSize) {
+    _tabViewProvider.fontSize = [NSNumber numberWithInt:newViewProps.fontSize];
+  }
+  
+  if (oldViewProps.fontWeight != newViewProps.fontWeight) {
+    _tabViewProvider.fontWeigth = RCTNSStringFromStringNilIfEmpty(newViewProps.fontWeight);
+  }
+  
+  if (oldViewProps.fontFamily != newViewProps.fontFamily) {
+    _tabViewProvider.fontFamily = RCTNSStringFromStringNilIfEmpty(newViewProps.fontFamily);
+  }
 
   [super updateProps:props oldProps:oldProps];
 }
@@ -179,7 +191,12 @@ NSArray* convertItemsToArray(const std::vector<RNCTabViewItemsStruct>& items) {
   NSMutableArray<TabInfo *> *result = [NSMutableArray array];
 
   for (const auto& item : items) {
-    auto tabInfo = [[TabInfo alloc] initWithKey:RCTNSStringFromString(item.key) title:RCTNSStringFromString(item.title) badge:RCTNSStringFromString(item.badge) sfSymbol:RCTNSStringFromString(item.sfSymbol) activeTintColor:RCTUIColorFromSharedColor(item.activeTintColor) hidden:item.hidden];
+    auto tabInfo = [[TabInfo alloc] initWithKey:RCTNSStringFromString(item.key)
+                                          title:RCTNSStringFromString(item.title)
+                                          badge:RCTNSStringFromStringNilIfEmpty(item.badge)
+                                       sfSymbol:RCTNSStringFromStringNilIfEmpty(item.sfSymbol)
+                                activeTintColor:RCTUIColorFromSharedColor(item.activeTintColor)
+                                         hidden:item.hidden];
 
     [result addObject:tabInfo];
   }

--- a/ios/RCTTabViewViewManager.mm
+++ b/ios/RCTTabViewViewManager.mm
@@ -43,6 +43,9 @@ RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(activeTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(inactiveTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(hapticFeedbackEnabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(fontFamily, NSString)
+RCT_EXPORT_VIEW_PROPERTY(fontWeight, NSString)
+RCT_EXPORT_VIEW_PROPERTY(fontSize, NSNumber)
 
 //  MARK: TabViewProviderDelegate
 

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -22,6 +22,9 @@ class TabViewProps: ObservableObject {
   @Published var ignoresTopSafeArea: Bool = true
   @Published var disablePageAnimations: Bool = false
   @Published var hapticFeedbackEnabled: Bool = true
+  @Published var fontSize: Int?
+  @Published var fontFamily: String?
+  @Published var fontWeight: String?
 
   var selectedActiveTintColor: UIColor? {
     if let selectedPage = selectedPage,
@@ -166,36 +169,100 @@ struct TabItem: View {
 }
 
 private func updateTabBarAppearance(props: TabViewProps, tabBar: UITabBar?) {
-  guard let tabBar else { return }
-  let appearanceType = props.scrollEdgeAppearance
+    guard let tabBar else { return }
+    
+    if props.scrollEdgeAppearance == "transparent" {
+        configureTransparentAppearance(tabBar: tabBar, props: props)
+        return
+    }
+    
+    configureStandardAppearance(tabBar: tabBar, props: props)
+}
 
-  if (appearanceType == "transparent") {
-    tabBar.barTintColor = props.barTintColor
-    tabBar.isTranslucent = props.translucent
-    tabBar.unselectedItemTintColor = props.inactiveTintColor
-    return
+private func createFontAttributes(
+  size: CGFloat,
+  family: String?,
+  weight: String?,
+  inactiveTintColor: UIColor?
+) -> [NSAttributedString.Key: Any] {
+  var attributes: [NSAttributedString.Key: Any] = [:]
+  
+  if let inactiveTintColor {
+    attributes[.foregroundColor] = inactiveTintColor
   }
+  
+  if family != nil || weight != nil {
+    attributes[.font] = RCTFont.update(
+      nil,
+      withFamily: family,
+      size: NSNumber(value: size),
+      weight: weight,
+      style: nil,
+      variant: nil,
+      scaleMultiplier: 1.0
+    )
+  } else {
+    attributes[.font] = UIFont.boldSystemFont(ofSize: size)
+  }
+  
+  return attributes
+}
 
+private func configureTransparentAppearance(tabBar: UITabBar, props: TabViewProps) {
+  tabBar.barTintColor = props.barTintColor
+  tabBar.isTranslucent = props.translucent
+  tabBar.unselectedItemTintColor = props.inactiveTintColor
+  
+  guard let items = tabBar.items else { return }
+  
+  let fontSize = props.fontSize ?? 14
+  let attributes = createFontAttributes(
+    size: CGFloat(fontSize),
+    family: props.fontFamily,
+    weight: props.fontWeight,
+    inactiveTintColor: props.inactiveTintColor
+  )
+  
+  items.forEach { item in
+    item.setTitleTextAttributes(attributes, for: .normal)
+  }
+}
+
+private func configureStandardAppearance(tabBar: UITabBar, props: TabViewProps) {
   let appearance = UITabBarAppearance()
   
-  switch appearanceType {
+  // Configure background
+  switch props.scrollEdgeAppearance {
   case "opaque":
     appearance.configureWithOpaqueBackground()
   default:
     appearance.configureWithDefaultBackground()
   }
   appearance.backgroundColor = props.barTintColor
-
+  
+  // Configure item appearance
+  let itemAppearance = UITabBarItemAppearance()
+  let fontSize = props.fontSize != nil ? CGFloat(props.fontSize!) : UIFont.smallSystemFontSize
+  
+  let attributes = createFontAttributes(
+    size: fontSize,
+    family: props.fontFamily,
+    weight: props.fontWeight,
+    inactiveTintColor: props.inactiveTintColor
+  )
+  
   if let inactiveTintColor = props.inactiveTintColor {
-    let itemAppearance = UITabBarItemAppearance()
     itemAppearance.normal.iconColor = inactiveTintColor
-    itemAppearance.normal.titleTextAttributes = [.foregroundColor: inactiveTintColor]
-
-    appearance.stackedLayoutAppearance = itemAppearance
-    appearance.inlineLayoutAppearance = itemAppearance
-    appearance.compactInlineLayoutAppearance = itemAppearance
   }
-
+  
+  itemAppearance.normal.titleTextAttributes = attributes
+  
+  // Apply item appearance to all layouts
+  appearance.stackedLayoutAppearance = itemAppearance
+  appearance.inlineLayoutAppearance = itemAppearance
+  appearance.compactInlineLayoutAppearance = itemAppearance
+  
+  // Apply final appearance
   tabBar.standardAppearance = appearance
   if #available(iOS 15.0, *) {
     tabBar.scrollEdgeAppearance = appearance.copy()
@@ -270,6 +337,15 @@ extension View {
         updateTabBarAppearance(props: props, tabBar: tabBar)
       }
       .onChange(of: props.selectedActiveTintColor) { newValue in
+        updateTabBarAppearance(props: props, tabBar: tabBar)
+      }
+      .onChange(of: props.fontSize) { newValue in
+        updateTabBarAppearance(props: props, tabBar: tabBar)
+      }
+      .onChange(of: props.fontFamily) { newValue in
+        updateTabBarAppearance(props: props, tabBar: tabBar)
+      }
+      .onChange(of: props.fontWeight) { newValue in
         updateTabBarAppearance(props: props, tabBar: tabBar)
       }
   }

--- a/ios/TabViewImpl.swift
+++ b/ios/TabViewImpl.swift
@@ -170,12 +170,12 @@ struct TabItem: View {
 
 private func updateTabBarAppearance(props: TabViewProps, tabBar: UITabBar?) {
     guard let tabBar else { return }
-    
+
     if props.scrollEdgeAppearance == "transparent" {
         configureTransparentAppearance(tabBar: tabBar, props: props)
         return
     }
-    
+
     configureStandardAppearance(tabBar: tabBar, props: props)
 }
 
@@ -186,11 +186,11 @@ private func createFontAttributes(
   inactiveTintColor: UIColor?
 ) -> [NSAttributedString.Key: Any] {
   var attributes: [NSAttributedString.Key: Any] = [:]
-  
+
   if let inactiveTintColor {
     attributes[.foregroundColor] = inactiveTintColor
   }
-  
+
   if family != nil || weight != nil {
     attributes[.font] = RCTFont.update(
       nil,
@@ -204,7 +204,7 @@ private func createFontAttributes(
   } else {
     attributes[.font] = UIFont.boldSystemFont(ofSize: size)
   }
-  
+
   return attributes
 }
 
@@ -212,17 +212,17 @@ private func configureTransparentAppearance(tabBar: UITabBar, props: TabViewProp
   tabBar.barTintColor = props.barTintColor
   tabBar.isTranslucent = props.translucent
   tabBar.unselectedItemTintColor = props.inactiveTintColor
-  
+
   guard let items = tabBar.items else { return }
-  
-  let fontSize = props.fontSize ?? 14
+
+  let fontSize = props.fontSize != nil ? CGFloat(props.fontSize!) : UIFont.smallSystemFontSize
   let attributes = createFontAttributes(
-    size: CGFloat(fontSize),
+    size: fontSize,
     family: props.fontFamily,
     weight: props.fontWeight,
     inactiveTintColor: props.inactiveTintColor
   )
-  
+
   items.forEach { item in
     item.setTitleTextAttributes(attributes, for: .normal)
   }
@@ -230,7 +230,7 @@ private func configureTransparentAppearance(tabBar: UITabBar, props: TabViewProp
 
 private func configureStandardAppearance(tabBar: UITabBar, props: TabViewProps) {
   let appearance = UITabBarAppearance()
-  
+
   // Configure background
   switch props.scrollEdgeAppearance {
   case "opaque":
@@ -239,29 +239,29 @@ private func configureStandardAppearance(tabBar: UITabBar, props: TabViewProps) 
     appearance.configureWithDefaultBackground()
   }
   appearance.backgroundColor = props.barTintColor
-  
+
   // Configure item appearance
   let itemAppearance = UITabBarItemAppearance()
   let fontSize = props.fontSize != nil ? CGFloat(props.fontSize!) : UIFont.smallSystemFontSize
-  
+
   let attributes = createFontAttributes(
     size: fontSize,
     family: props.fontFamily,
     weight: props.fontWeight,
     inactiveTintColor: props.inactiveTintColor
   )
-  
+
   if let inactiveTintColor = props.inactiveTintColor {
     itemAppearance.normal.iconColor = inactiveTintColor
   }
-  
+
   itemAppearance.normal.titleTextAttributes = attributes
-  
+
   // Apply item appearance to all layouts
   appearance.stackedLayoutAppearance = itemAppearance
   appearance.inlineLayoutAppearance = itemAppearance
   appearance.compactInlineLayoutAppearance = itemAppearance
-  
+
   // Apply final appearance
   tabBar.standardAppearance = appearance
   if #available(iOS 15.0, *) {

--- a/ios/TabViewProvider.swift
+++ b/ios/TabViewProvider.swift
@@ -130,6 +130,24 @@ import React
       props.inactiveTintColor = inactiveTintColor
     }
   }
+  
+  @objc public var fontFamily: NSString? {
+    didSet {
+      props.fontFamily = fontFamily as? String
+    }
+  }
+  
+  @objc public var fontWeigth: NSString? {
+    didSet {
+      props.fontWeight = fontWeigth as? String
+    }
+  }
+  
+  @objc public var fontSize: NSNumber? {
+    didSet {
+      props.fontSize = fontSize as? Int
+    }
+  }
 
   // New arch specific properties
 

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -123,6 +123,18 @@ interface Props<Route extends BaseRoute> {
    * Color of tab indicator. (Android only)
    */
   activeIndicatorColor?: ColorValue;
+  /**
+   * Font family for the tab labels.
+   */
+  fontFamily?: string;
+  /**
+   * Font weight for the tab labels.
+   */
+  fontWeight?: string;
+  /**
+   * Font size for the tab labels.
+   */
+  fontSize?: number;
 }
 
 const ANDROID_MAX_TABS = 6;

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -123,18 +123,22 @@ interface Props<Route extends BaseRoute> {
    * Color of tab indicator. (Android only)
    */
   activeIndicatorColor?: ColorValue;
-  /**
-   * Font family for the tab labels.
-   */
-  fontFamily?: string;
-  /**
-   * Font weight for the tab labels.
-   */
-  fontWeight?: string;
-  /**
-   * Font size for the tab labels.
-   */
-  fontSize?: number;
+  tabLabelStyle?: {
+    /**
+     * Font family for the tab labels.
+     */
+    fontFamily?: string;
+
+    /**
+     * Font weight for the tab labels.
+     */
+    fontWeight?: string;
+
+    /**
+     * Font size for the tab labels.
+     */
+    fontSize?: number;
+  };
 }
 
 const ANDROID_MAX_TABS = 6;
@@ -160,6 +164,7 @@ const TabView = <Route extends BaseRoute>({
   getHidden = ({ route }: { route: Route }) => route.hidden,
   getActiveTintColor = ({ route }: { route: Route }) => route.activeTintColor,
   hapticFeedbackEnabled = true,
+  tabLabelStyle,
   ...props
 }: Props<Route>) => {
   // @ts-ignore
@@ -250,6 +255,7 @@ const TabView = <Route extends BaseRoute>({
   return (
     <TabViewAdapter
       {...props}
+      {...tabLabelStyle}
       style={styles.fullWidth}
       items={items}
       icons={resolvedIconAssets}

--- a/src/TabViewNativeComponent.ts
+++ b/src/TabViewNativeComponent.ts
@@ -2,6 +2,7 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 import type { ColorValue, ProcessedColorValue, ViewProps } from 'react-native';
 import type {
   DirectEventHandler,
+  Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
 //@ts-ignore
@@ -38,6 +39,9 @@ export interface TabViewProps extends ViewProps {
   disablePageAnimations?: boolean;
   activeIndicatorColor?: ColorValue;
   hapticFeedbackEnabled?: boolean;
+  fontFamily?: string;
+  fontWeight?: string;
+  fontSize?: Int32;
 }
 
 export default codegenNativeComponent<TabViewProps>('RNCTabView', {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,9 @@ export type BaseRoute = {
   unfocusedIcon?: ImageSourcePropType | AppleIcon;
   activeTintColor?: string;
   hidden?: boolean;
+  fontFamily?: string;
+  fontWeight?: string;
+  fontSize?: number;
 };
 
 export type NavigationState<Route extends BaseRoute> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,9 +14,6 @@ export type BaseRoute = {
   unfocusedIcon?: ImageSourcePropType | AppleIcon;
   activeTintColor?: string;
   hidden?: boolean;
-  fontFamily?: string;
-  fontWeight?: string;
-  fontSize?: number;
 };
 
 export type NavigationState<Route extends BaseRoute> = {


### PR DESCRIPTION
This PR adds custom font support.

![CleanShot 2024-11-09 at 15 15 28@2x](https://github.com/user-attachments/assets/d5755f14-2de9-490a-9df5-ef4da696ef5e)

Solves #107 

Fonts can be defined on the navigator level like so:

```tsx
    <Tab.Navigator
      tabLabelStyle={{
        fontFamily: 'Avenir',
        fontSize: 15,
      }}
    >
```