### PR TITLE
docs: instruct users to use one config plugin

### DIFF
--- a/docs/docs/docs/guides/edge-to-edge-support.md
+++ b/docs/docs/docs/guides/edge-to-edge-support.md
@@ -4,6 +4,26 @@ React Native Bottom Tabs supports edge-to-edge navigation on Android.
 
 In order to enable edge-to-edge follow installation instructions for [react-native-edge-to-edge](https://github.com/zoontek/react-native-edge-to-edge).
 
+:::note
+
+When using `react-native-edge-to-edge` config plugin, you don't need `react-native-bottom-tabs` config plugin. Make sure to set `parentTheme` to be either `Material2` or `Material3`.
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-edge-to-edge",
+        { "android": { "parentTheme": "Material3" } }
+      ]
+    ]
+  }
+}
+```
+
+:::
+
+
 Once this package is installed, this library will automatically use it to enable edge-to-edge navigation on Android.
 
 | Before | After |


### PR DESCRIPTION
This PR instructs users to use only use config plugin when using `react-native-edge-to-edge`.