### PR TITLE
Fix ios build on old xcode

### DIFF
--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -39,6 +39,7 @@ extension UIImage {
 }
 
 extension View {
+  @MainActor
   @ViewBuilder
   func introspectTabView(closure: @escaping (UITabBarController) -> Void) -> some View {
     self


### PR DESCRIPTION
Version >=0.5.0 was failing to build on XCode 15.2:

```
func introspectTabView(closure: @escaping (UITabBarController) -> Void) -> some View {
  44 |     self
> 45 |       .introspect(
     |        ^ call to main actor-isolated instance method 'introspect' in a synchronous nonisolated context
```

 I think it's related to a recent change to @MainActor in XCode 16?

Whatever the case, the package is building for me with this change 🙌