### PR TITLE
fix: remove tab bar icon workaround

### DIFF
--- a/.changeset/bright-pianos-invite.md
+++ b/.changeset/bright-pianos-invite.md
@@ -1,0 +1,5 @@
+---
+"@bottom-tabs/react-navigation": patch
+---
+
+fix: remove `tabBarIcon` from experimental API 

--- a/packages/react-navigation/src/types.ts
+++ b/packages/react-navigation/src/types.ts
@@ -68,12 +68,6 @@ export type NativeBottomTabNavigationOptions = {
   tabBarIcon?: (props: { focused: boolean }) => ImageSourcePropType | AppleIcon;
 
   /**
-   * Whether the tab bar item is visible when this screen is active.
-   * Used for compatibility with JS Tabs. Prefer using `tabBarItemHidden` as this API may be removed in the future.
-   */
-  tabBarButton?: () => null;
-
-  /**
    * Whether the tab bar item is visible. Defaults to true.
    */
   tabBarItemHidden?: boolean;

--- a/packages/react-navigation/src/views/NativeBottomTabView.tsx
+++ b/packages/react-navigation/src/views/NativeBottomTabView.tsx
@@ -42,11 +42,7 @@ export default function NativeBottomTabView({
       getBadge={({ route }) => descriptors[route.key]?.options.tabBarBadge}
       getHidden={({ route }) => {
         const options = descriptors[route.key]?.options;
-
-        return (
-          options?.tabBarItemHidden === true ||
-          options?.tabBarButton?.() === null
-        );
+        return options?.tabBarItemHidden === true;
       }}
       getIcon={({ route, focused }) => {
         const options = descriptors[route.key]?.options;


### PR DESCRIPTION
## PR Description

This PR removes the tab bar icon workaround as it's not needed anymore 

## How to test?

CI Green

## Screenshots

N/A