### PR TITLE
fix(ios): correctly handle active items for scroll edge transparent

### DIFF
--- a/.changeset/modern-seas-pull.md
+++ b/.changeset/modern-seas-pull.md
@@ -1,0 +1,5 @@
+---
+"react-native-bottom-tabs": patch
+---
+
+fix(ios): correctly handle active items for scroll edge transparent

--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -195,9 +195,6 @@ private func createFontAttributes(
 ) -> [NSAttributedString.Key: Any] {
   var attributes: [NSAttributedString.Key: Any] = [:]
 
-  if let inactiveTintColor {
-    attributes[.foregroundColor] = inactiveTintColor
-  }
 
   if family != nil || weight != nil {
     attributes[.font] = RCTFont.update(
@@ -258,12 +255,16 @@ private func configureStandardAppearance(tabBar: UITabBar, props: TabViewProps) 
   let itemAppearance = UITabBarItemAppearance()
   let fontSize = props.fontSize != nil ? CGFloat(props.fontSize!) : tabBarDefaultFontSize
 
-  let attributes = createFontAttributes(
+  var attributes = createFontAttributes(
     size: fontSize,
     family: props.fontFamily,
     weight: props.fontWeight,
     inactiveTintColor: props.inactiveTintColor
   )
+  
+  if let inactiveTintColor = props.inactiveTintColor {
+    attributes[.foregroundColor] = inactiveTintColor
+  }
 
   if let inactiveTintColor = props.inactiveTintColor {
     itemAppearance.normal.iconColor = inactiveTintColor


### PR DESCRIPTION

## PR Description

This PR correctly handles scrollEdgeApperance transparent active indicator text, reported in #164 

## How to test?


Follow steps in #164

## Screenshots

https://github.com/user-attachments/assets/a7227010-6b75-405e-9a47-16da5b1c52b6

