### PR TITLE
fix: android tabBarIcon not visible when build to apk

### DIFF
--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -6,6 +6,7 @@ import android.content.res.ColorStateList
 import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.os.Build
 import android.util.Log
 import android.util.TypedValue
@@ -180,10 +181,27 @@ class ReactBottomNavigationView(context: Context) : BottomNavigationView(context
     itemRippleColor = color
   }
 
+  private fun formatUri(uri: Uri): Uri {
+    return when (uri.scheme) {
+      "res" -> {
+        val uriString = uri.toString()
+        val parts = uriString.split(":/")
+        
+        if (parts.size > 1) {
+          val resourceId = parts[1].toIntOrNull()
+          Uri.parse("android.resource://${context.packageName}/${resourceId}")
+        } else {
+          uri
+        }
+      }
+      else -> uri
+    }
+  }
+
   @SuppressLint("CheckResult")
   private fun getDrawable(imageSource: ImageSource, onDrawableReady: (Drawable?) -> Unit) {
     val request = ImageRequest.Builder(context)
-      .data(imageSource.uri)
+      .data(formatUri(imageSource.uri))
       .target { drawable ->
         post { onDrawableReady(drawable.asDrawable(context.resources)) }
       }


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description

I found that the image processing on Android uses [Coil](https://github.com/coil-kt/coil). 

https://github.com/okwasniewski/react-native-bottom-tabs/blob/fc096decd22603ab92c2da290f1dd4f1a2b774d4/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt#L184-L198


- When in expo dev, assets are served over HTTP (According to [expo Assets](https://docs.expo.dev/develop/user-interface/assets/#how-are-assets-served-locally)), the `imageSource.uri` looks like `http://localhost:8081/assets/xxxx` and Coil handles it well
- When build to apk, the `imageSource.uri` looks like `res:/2131165303`, Coil cannot handle this and will cause error

Need format

<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->

## How to test?

Test on my Android device

<!-- Please provide the steps to test the changes you made. -->

## Screenshots

<!-- If applicable, add screenshots or videos to help explain your changes. -->

### Before
![image](https://github.com/user-attachments/assets/52c59830-3caa-4d40-b61e-25b8201eeae8)

### After
![image](https://github.com/user-attachments/assets/087ba235-e1db-406c-9ae7-fef0268f675e)




