### PR TITLE
Fix a bug that active tab label shows with inactive color

### DIFF
--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -231,7 +231,7 @@ private func configureTransparentAppearance(tabBar: UITabBar, props: TabViewProp
     size: fontSize,
     family: props.fontFamily,
     weight: props.fontWeight,
-    inactiveTintColor: props.inactiveTintColor
+    inactiveTintColor: nil
   )
 
   items.forEach { item in


### PR DESCRIPTION
In scrollEdgeAppearance : 'transparent' mode the active tab appear its label with inactive tint color

<!-- Please provide information about your pull request. -->

## PR Description

<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->

## How to test?

<!-- Please provide the steps to test the changes you made. -->

## Screenshots

<!-- If applicable, add screenshots or videos to help explain your changes. -->
