### PR TITLE
fix(docs): wrong default value for labeled prop

### DIFF
--- a/docs/docs/docs/guides/standalone-usage.md
+++ b/docs/docs/docs/guides/standalone-usage.md
@@ -107,7 +107,8 @@ Callback that is called when the tab index changes.
 
 Whether to show labels in tabs. When `false`, only icons will be displayed.
 - Type: `boolean`
-- Default: `true`
+- Default <Badge text="iOS" type="info" />: `true`
+- Default <Badge text="Android" type="info" />: `false`
 
 #### `sidebarAdaptable` <Badge text="iOS" type="info" />
 

--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -95,7 +95,10 @@ It supports the following values:
 
 #### `labeled`
 
-Whether to show labels in tabs. Defaults to true.
+Whether to show labels in tabs.
+- Type: `boolean`
+- Default <Badge text="iOS" type="info" />: `true`
+- Default <Badge text="Android" type="info" />: `false`
 
 #### `rippleColor` <Badge text="android" type="info" />
 


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description

Default value is wrong because labels are by default hidden on Android when tab is not focused.

## How to test?

<!-- Please provide the steps to test the changes you made. -->

## Screenshots

<!-- If applicable, add screenshots or videos to help explain your changes. -->
