### PR TITLE
fix: properly set translucent prop on iOS

### DIFF
--- a/.changeset/new-kiwis-clean.md
+++ b/.changeset/new-kiwis-clean.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+fix: properly set translucent prop on iOS

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -1209,7 +1209,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-bottom-tabs (0.7.1):
+  - react-native-bottom-tabs (0.7.3):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
@@ -1222,7 +1222,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-bottom-tabs/common (= 0.7.1)
+    - react-native-bottom-tabs/common (= 0.7.3)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1234,7 +1234,7 @@ PODS:
     - SDWebImageSVGCoder (>= 1.7.0)
     - SwiftUIIntrospect (~> 1.0)
     - Yoga
-  - react-native-bottom-tabs/common (0.7.1):
+  - react-native-bottom-tabs/common (0.7.3):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
@@ -1761,8 +1761,6 @@ DEPENDENCIES:
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../../../node_modules/react-native-screens`)
   - RNVectorIcons (from `../../../node_modules/react-native-vector-icons`)
-  - SDWebImage
-  - SDWebImageSVGCoder
   - Yoga (from `../../../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -1945,7 +1943,7 @@ SPEC CHECKSUMS:
   React-logger: d79b704bf215af194f5213a6b7deec50ba8e6a9b
   React-Mapbuffer: b982d5bba94a8bc073bda48f0d27c9b28417fae3
   React-microtasksnativemodule: 8fa285fed833a04a754bf575f8ded65fc240b88d
-  react-native-bottom-tabs: a08eaf6baf1b78375e17019536783dbbca3190ba
+  react-native-bottom-tabs: b6b3dc2e971c860a0a6d763701929d1899f666a0
   react-native-safe-area-context: 73505107f7c673cd550a561aeb6271f152c483b6
   React-nativeconfig: 8c83d992b9cc7d75b5abe262069eaeea4349f794
   React-NativeModulesApple: b8465afc883f5bf3fe8bac3767e394d581a5f123
@@ -1984,6 +1982,6 @@ SPEC CHECKSUMS:
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
   Yoga: 055f92ad73f8c8600a93f0e25ac0b2344c3b07e6
 
-PODFILE CHECKSUM: 1c1dbca3e400ef935aa9a150cb2dcb58fb8c4536
+PODFILE CHECKSUM: a8893a4bb2afbd979cd364e553bb6f2186c2ce27
 
 COCOAPODS: 1.15.2

--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -199,6 +199,7 @@ private func configureTransparentAppearance(tabBar: UITabBar, props: TabViewProp
 
 private func configureStandardAppearance(tabBar: UITabBar, props: TabViewProps) {
   let appearance = UITabBarAppearance()
+  tabBar.isTranslucent = props.translucent
 
   // Configure background
   switch props.scrollEdgeAppearance {

--- a/packages/react-native-bottom-tabs/src/TabViewNativeComponent.ts
+++ b/packages/react-native-bottom-tabs/src/TabViewNativeComponent.ts
@@ -44,7 +44,7 @@ export interface TabViewProps extends ViewProps {
   sidebarAdaptable?: boolean;
   scrollEdgeAppearance?: string;
   barTintColor?: ColorValue;
-  translucent?: boolean;
+  translucent?: WithDefault<boolean, true>;
   rippleColor?: ColorValue;
   activeTintColor?: ColorValue;
   inactiveTintColor?: ColorValue;

--- a/turbo.json
+++ b/turbo.json
@@ -61,11 +61,11 @@
     "build:ios": {
       "env": ["RCT_NEW_ARCH_ENABLED"],
       "inputs": [
-        "packages/*/package.json",
-        "packages/*/*.podspec",
-        "packages/*/ios",
-        "packages/*/src/*.ts",
-        "packages/*/src/*.tsx",
+        "package.json",
+        "*.podspec",
+        "ios",
+        "src/*.ts",
+        "src/*.tsx",
         "apps/example/package.json",
         "apps/example/ios",
         "!apps/example/ios/build",
@@ -76,11 +76,11 @@
     "build:macos": {
       "env": ["RCT_NEW_ARCH_ENABLED"],
       "inputs": [
-        "packages/*/package.json",
-        "packages/*/*.podspec",
-        "packages/*/ios",
-        "packages/*/src/*.ts",
-        "packages/*/src/*.tsx",
+        "package.json",
+        "*.podspec",
+        "ios",
+        "src/*.ts",
+        "src/*.tsx",
         "apps/example/package.json",
         "apps/example/macos",
         "!apps/example/macos/build",
@@ -91,11 +91,11 @@
     "build:ios-expo": {
       "env": ["RCT_NEW_ARCH_ENABLED"],
       "inputs": [
-        "packages/*/package.json",
-        "packages/*/*.podspec",
-        "packages/*/ios",
-        "packages/*/src/*.ts",
-        "packages/*/src/*.tsx",
+        "package.json",
+        "*.podspec",
+        "ios",
+        "src/*.ts",
+        "src/*.tsx",
         "apps/example-expo/package.json"
       ],
       "outputs": []


### PR DESCRIPTION
## PR Description

This PR properly sets translucent prop on iOS, thanks @jbroma for reporting the issue! 

## How to test?

Set `translucent={false}`

## Screenshots

![CleanShot 2024-12-11 at 09 59 42@2x](https://github.com/user-attachments/assets/a506c84a-62a9-4059-be95-8b8f43017327)

