### PR TITLE
Fix/translucent with default scroll edge

### DIFF
--- a/.changeset/curly-snails-crash.md
+++ b/.changeset/curly-snails-crash.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+fix: make translucent prop work properly with default apperance

--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -199,7 +199,6 @@ private func configureTransparentAppearance(tabBar: UITabBar, props: TabViewProp
 
 private func configureStandardAppearance(tabBar: UITabBar, props: TabViewProps) {
   let appearance = UITabBarAppearance()
-  tabBar.isTranslucent = props.translucent
 
   // Configure background
   switch props.scrollEdgeAppearance {
@@ -208,8 +207,15 @@ private func configureStandardAppearance(tabBar: UITabBar, props: TabViewProps) 
   default:
     appearance.configureWithDefaultBackground()
   }
-  appearance.backgroundColor = props.barTintColor
-
+  
+  if props.translucent == false {
+    appearance.configureWithOpaqueBackground()
+  }
+  
+  if props.barTintColor != nil {
+    appearance.backgroundColor = props.barTintColor
+  }
+  
   // Configure item appearance
   let itemAppearance = UITabBarItemAppearance()
   let fontSize = props.fontSize != nil ? CGFloat(props.fontSize!) : tabBarDefaultFontSize


### PR DESCRIPTION
## PR Description

This PR brings in an older fix that got removed during a refactor, now it works properly when we set translucent={false}

## How to test?

Set translucent={false}

## Screenshots

N/a